### PR TITLE
Set UDP sockets created by StatsdClient to non-blocking mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,15 @@
   [#12](https://github.com/tshlabs/cadence/issues/12).
 * Improve documentation around `MetricSink` trait per
   [#13](https://github.com/tshlabs/cadence/issues/13).
+* **Behavior change** - Change UDP sockets created by
+  `StatsdClient::from_udp_host` to be created in non-blocking mode by default
+  per [#14](https://github.com/tshlabs/cadence/issues/14). While this does
+  change previous behavior, users of the library shouldn't notice much of
+  a change. In instances where the caller would have blocked before, they
+  will get a `MetricError` wrapping an `io::Error` (with an `ErrorKind` of
+  `WouldBlock`). Users wishing to restore the old behavior can do so by
+  creating a custom instance of `UdpMetricSink`. Thanks to the
+  [Tikv](https://github.com/pingcap/tikv) team for the inspiration.
 
 ## [v0.5.2](https://github.com/tshlabs/cadence/tree/0.5.2) - 2016-07-02
 * Increase test coverage per [#10](https://github.com/tshlabs/cadence/issues/10).

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ use cadence::{StatsdClient, UdpMetricSink, DEFAULT_PORT};
 
 // Create client that will write to the given host over UDP.
 //
-// Note that you'll probably want to actually handle any errors creating the client
-// when you use it for real in your application. We're just using .unwrap() here
-// since this is an example!
+// Note that you'll probably want to actually handle any errors creating
+// the client when you use it for real in your application. We're just
+// using .unwrap() here since this is an example!
 let host = ("metrics.example.com", DEFAULT_PORT);
 let client = StatsdClient::<UdpMetricSink>::from_udp_host(
     "my.metrics", host).unwrap();
@@ -83,13 +83,14 @@ client.meter("some.value", 5);
 
 ### Counted, Timed, Gauged, and Metered Traits
 
-Each of the methods that the Cadence `StatsdClient` struct uses to send metrics are
-implemented as a trait. If we want, we can just use the trait type to refer to the
-client instance. This might be useful to you if you'd like to swap out the actual
-Cadence client with a dummy version when you are unit testing your code.
+Each of the methods that the Cadence `StatsdClient` struct uses to send
+metrics are implemented as a trait. If we want, we can just use the trait
+type to refer to the client instance. This might be useful to you if you'd
+like to swap out the actual Cadence client with a dummy version when you
+are unit testing your code.
 
-Each of these traits are exported in the prelude module. They are also available
-in the main module but aren't typically used like that.
+Each of these traits are exported in the prelude module. They are also
+available in the main module but aren't typically used like that.
 
 ``` rust,no_run
 use cadence::prelude::*;
@@ -142,14 +143,14 @@ match dao.get_user_by_id(123) {
 
 ### Custom Metric Sinks
 
-The Cadence `StatsdClient` uses implementations of the `MetricSink` trait to
-send metrics to a metric server. Most users of the Candence library probably
-want to use the `UdpMetricSink` implementation. This is the way people typically
-interact with a Statsd server, sending packets over UDP.
+The Cadence `StatsdClient` uses implementations of the `MetricSink` trait
+to send metrics to a metric server. Most users of the Candence library
+probably want to use the `UdpMetricSink` implementation. This is the way
+people typically interact with a Statsd server, sending packets over UDP.
 
-However, maybe you'd like to do something custom: use a thread pool, send multiple
-metrics at the same time, or something else. An example of creating a custom sink
-is below.
+However, maybe you'd like to do something custom: use a thread pool,
+send multiple metrics at the same time, or something else. An example
+of creating a custom sink is below.
 
 ``` rust,no_run
 use std::io;
@@ -177,17 +178,19 @@ client.incr("some.other.counter");
 
 ### Custom UDP Socket
 
-Most users of the Cadence `StatsdClient` will be using it to send metrics over
-a UDP socket. If you need to customize the socket, for example you want to make
-sure it won't block, you can do that as demonstrated below.
+Most users of the Cadence `StatsdClient` will be using it to send metrics
+over a UDP socket. If you need to customize the socket, for example you
+want to use the socket in blocking mode but set a write timeout, you can
+do that as demonstrated below.
 
 ``` rust,no_run
 use std::net::UdpSocket;
+use std::time::Duration;
 use cadence::prelude::*;
 use cadence::{StatsdClient, UdpMetricSink, DEFAULT_PORT};
 
 let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
-socket.set_nonblocking(true).unwrap();
+socket.set_write_timeout(Some(Duration::from_millis(1))).unwrap();
 
 let host = ("metrics.example.com", DEFAULT_PORT);
 let sink = UdpMetricSink::from(host, socket).unwrap();

--- a/src/client.rs
+++ b/src/client.rs
@@ -114,7 +114,7 @@ impl<T: MetricSink> StatsdClient<T> {
     /// let client = StatsdClient::from_sink(prefix, NopMetricSink);
     /// ```
     ///
-    /// # Non-blocking UDP Example
+    /// # UDP Socket Example
     ///
     /// ```
     /// use std::net::UdpSocket;
@@ -140,9 +140,7 @@ impl<T: MetricSink> StatsdClient<T> {
     /// metrics to the given host over UDP using an appropriate sink. This is
     /// the construction method that most users of this library will use.
     ///
-    /// The UDP socket will not be put into non-blocking mode. Callers that
-    /// wish to use a non-blocking socket should use the `from_sink` method
-    /// with a custom instance of `UdpMetricSink`.
+    /// The created UDP socket will be put into non-blocking mode.
     ///
     /// **Note** that you must include a type parameter when you call this
     /// method to help the compiler determine the type of `T` (the sink).
@@ -164,12 +162,14 @@ impl<T: MetricSink> StatsdClient<T> {
     /// This method may fail if:
     ///
     /// * It is unable to create a local UDP socket.
+    /// * It is unable to put the UDP socket into non-blocking mode.
     /// * It is unable to resolve the hostname of the metric server.
     /// * The host address is otherwise unable to be parsed.
     pub fn from_udp_host<A>(prefix: &str, host: A) -> MetricResult<StatsdClient<UdpMetricSink>>
         where A: ToSocketAddrs
     {
         let socket = try!(UdpSocket::bind("0.0.0.0:0"));
+        try!(socket.set_nonblocking(true));
         let sink = try!(UdpMetricSink::from(host, socket));
         Ok(StatsdClient::from_sink(prefix, sink))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,9 +59,9 @@
 //!
 //! ### Simple Use
 //!
-//! Simple usage of Cadence is shown below. In this example, we just import the client,
-//! create an instance that will write to some imaginary metrics server, and send a few
-//! metrics.
+//! Simple usage of Cadence is shown below. In this example, we just import
+//! the client, create an instance that will write to some imaginary metrics
+//! server, and send a few metrics.
 //!
 //! ``` rust,no_run
 //! // Import the client.
@@ -70,9 +70,9 @@
 //!
 //! // Create client that will write to the given host over UDP.
 //! //
-//! // Note that you'll probably want to actually handle any errors creating the client
-//! // when you use it for real in your application. We're just using .unwrap() here
-//! // since this is an example!
+//! // Note that you'll probably want to actually handle any errors creating
+//! // the client when you use it for real in your application. We're just
+//! // using .unwrap() here since this is an example!
 //! let host = ("metrics.example.com", DEFAULT_PORT);
 //! let client = StatsdClient::<UdpMetricSink>::from_udp_host(
 //!     "my.metrics", host).unwrap();
@@ -86,13 +86,14 @@
 //!
 //! ### Counted, Timed, Gauged, and Metered Traits
 //!
-//! Each of the methods that the Cadence `StatsdClient` struct uses to send metrics are
-//! implemented as a trait. If we want, we can just use the trait type to refer to the
-//! client instance. This might be useful to you if you'd like to swap out the actual
-//! Cadence client with a dummy version when you are unit testing your code.
+//! Each of the methods that the Cadence `StatsdClient` struct uses to send
+//! metrics are implemented as a trait. If we want, we can just use the trait
+//! type to refer to the client instance. This might be useful to you if you'd
+//! like to swap out the actual Cadence client with a dummy version when you
+//! are unit testing your code.
 //!
-//! Each of these traits are exported in the prelude module. They are also available
-//! in the main module but aren't typically used like that.
+//! Each of these traits are exported in the prelude module. They are also
+//! available in the main module but aren't typically used like that.
 //!
 //! ``` rust,no_run
 //! use cadence::prelude::*;
@@ -145,14 +146,14 @@
 //!
 //! ### Custom Metric Sinks
 //!
-//! The Cadence `StatsdClient` uses implementations of the `MetricSink` trait to
-//! send metrics to a metric server. Most users of the Candence library probably
-//! want to use the `UdpMetricSink` implementation. This is the way people typically
-//! interact with a Statsd server, sending packets over UDP.
+//! The Cadence `StatsdClient` uses implementations of the `MetricSink` trait
+//! to send metrics to a metric server. Most users of the Candence library
+//! probably want to use the `UdpMetricSink` implementation. This is the way
+//! people typically interact with a Statsd server, sending packets over UDP.
 //!
-//! However, maybe you'd like to do something custom: use a thread pool, send multiple
-//! metrics at the same time, or something else. An example of creating a custom sink
-//! is below.
+//! However, maybe you'd like to do something custom: use a thread pool,
+//! send multiple metrics at the same time, or something else. An example
+//! of creating a custom sink is below.
 //!
 //! ``` rust,no_run
 //! use std::io;
@@ -180,17 +181,19 @@
 //!
 //! ### Custom UDP Socket
 //!
-//! Most users of the Cadence `StatsdClient` will be using it to send metrics over
-//! a UDP socket. If you need to customize the socket, for example you want to make
-//! sure it won't block, you can do that as demonstrated below.
+//! Most users of the Cadence `StatsdClient` will be using it to send metrics
+//! over a UDP socket. If you need to customize the socket, for example you
+//! want to use the socket in blocking mode but set a write timeout, you can
+//! do that as demonstrated below.
 //!
 //! ``` rust,no_run
 //! use std::net::UdpSocket;
+//! use std::time::Duration;
 //! use cadence::prelude::*;
 //! use cadence::{StatsdClient, UdpMetricSink, DEFAULT_PORT};
 //!
 //! let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
-//! socket.set_nonblocking(true).unwrap();
+//! socket.set_write_timeout(Some(Duration::from_millis(1))).unwrap();
 //!
 //! let host = ("metrics.example.com", DEFAULT_PORT);
 //! let sink = UdpMetricSink::from(host, socket).unwrap();

--- a/src/sinks.rs
+++ b/src/sinks.rs
@@ -69,7 +69,8 @@ impl UdpMetricSink {
     ///
     /// The address should be the address of the remote metric server to
     /// emit metrics to over UDP. The socket should already be bound to a
-    /// local address.
+    /// local address with any desired configuration applied (blocking vs
+    /// non-blocking, timeouts, etc.).
     ///
     /// # Example
     ///
@@ -86,6 +87,10 @@ impl UdpMetricSink {
     /// in non-blocking mode before creating the UDP metric sink.
     ///
     /// # Non-blocking Example
+    ///
+    /// Note that putting the UDP socket into non-blocking mode is the
+    /// default when sink and socket are automatically created with the
+    /// `StatsdClient::from_udp_host` method.
     ///
     /// ```no_run
     /// use std::net::UdpSocket;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,6 +1,5 @@
 extern crate cadence;
 
-use std::net::UdpSocket;
 use std::thread;
 use std::time::Duration;
 use std::sync::Arc;
@@ -18,15 +17,6 @@ fn new_nop_client(prefix: &str) -> StatsdClient<NopMetricSink> {
 fn new_udp_client(prefix: &str) -> StatsdClient<UdpMetricSink> {
     let addr = ("127.0.0.1", DEFAULT_PORT);
     StatsdClient::<UdpMetricSink>::from_udp_host(prefix, addr).unwrap()
-}
-
-
-fn new_non_blocking_udp_client(prefix: &str) -> StatsdClient<UdpMetricSink> {
-    let addr = ("127.0.0.1", DEFAULT_PORT);
-    let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
-    socket.set_nonblocking(true).unwrap();
-    let sink = UdpMetricSink::from(addr, socket).unwrap();
-    StatsdClient::from_sink(prefix, sink)
 }
 
 
@@ -102,14 +92,6 @@ fn test_statsd_client_udp_sink_single_threaded() {
 }
 
 
-#[ignore]
-#[test]
-fn test_statsd_client_non_blocking_udp_sink_single_threaded() {
-    let client = new_non_blocking_udp_client("cadence");
-    run_threaded_test(client, 1, 1);
-}
-
-
 const NUM_THREADS: u64 = 100;
 const NUM_ITERATIONS: u64 = 1_000;
 
@@ -126,14 +108,6 @@ fn test_statsd_client_nop_sink_many_threaded() {
 #[test]
 fn test_statsd_client_udp_sink_many_threaded() {
     let client = new_udp_client("cadence");
-    run_threaded_test(client, NUM_THREADS, NUM_ITERATIONS);
-}
-
-
-#[ignore]
-#[test]
-fn test_statsd_client_non_blocking_udp_sink_many_threaded() {
-    let client = new_non_blocking_udp_client("cadence");
     run_threaded_test(client, NUM_THREADS, NUM_ITERATIONS);
 }
 


### PR DESCRIPTION
Create UDP sockets in non-blocking mode by default. This should result in a minimal behavior change for callers of the library. Callers wishing to restore the old behavior (blocking) can do so by creating a custom UdpMetricSink instance.

Fixes #14