### PR TITLE
Create `BufferedUdpMetricSink` that buffers metric lines before sending

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -4,9 +4,11 @@ extern crate cadence;
 
 use test::Bencher;
 
+use std::net::UdpSocket;
+
 use cadence::prelude::*;
 use cadence::{DEFAULT_PORT, StatsdClient, Counter, Timer, Gauge, Meter,
-              NopMetricSink, UdpMetricSink};
+              NopMetricSink, UdpMetricSink, BufferedUdpMetricSink};
 
 
 fn new_nop_client() -> StatsdClient<NopMetricSink> {
@@ -16,7 +18,16 @@ fn new_nop_client() -> StatsdClient<NopMetricSink> {
 
 fn new_udp_client() -> StatsdClient<UdpMetricSink> {
     let host = ("127.0.0.1", DEFAULT_PORT);
-    StatsdClient::<UdpMetricSink>::from_udp_host("test.bench.udp", host).unwrap()
+    StatsdClient::<UdpMetricSink>::from_udp_host(
+        "test.bench.udp", host).unwrap()
+}
+
+
+fn new_buffered_udp_client() -> StatsdClient<BufferedUdpMetricSink> {
+    let host = ("127.0.0.1", DEFAULT_PORT);
+    let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+    let sink = BufferedUdpMetricSink::from(host, socket).unwrap();
+    StatsdClient::from_sink("test.bench.buffered", sink)
 }
 
 
@@ -119,31 +130,72 @@ fn test_benchmark_statsdclient_mark_udp(b: &mut Bencher) {
 
 
 #[bench]
+fn test_benchmark_statsdclient_count_buffered_udp(b: &mut Bencher) {
+    let client = new_buffered_udp_client();
+    b.iter(|| client.count("some.counter", 4));
+}
+
+
+#[bench]
+fn test_benchmark_statsdclient_incr_buffered_udp(b: &mut Bencher) {
+    let client = new_buffered_udp_client();
+    b.iter(|| client.incr("some.counter.incr"));
+}
+
+
+#[bench]
+fn test_benchmark_statsdclient_decr_buffered_udp(b: &mut Bencher) {
+    let client = new_buffered_udp_client();
+    b.iter(|| client.decr("some.counter.decr"));
+}
+
+
+#[bench]
+fn test_benchmark_statsdclient_time_buffered_udp(b: &mut Bencher) {
+    let client = new_buffered_udp_client();
+    b.iter(|| client.time("some.timer", 4));
+}
+
+
+#[bench]
+fn test_benchmark_statsdclient_gauge_buffered_udp(b: &mut Bencher) {
+    let client = new_buffered_udp_client();
+    b.iter(|| client.gauge("some.gauge", 4));
+}
+
+
+#[bench]
+fn test_benchmark_statsdclient_meter_buffered_udp(b: &mut Bencher) {
+    let client = new_buffered_udp_client();
+    b.iter(|| client.meter("some.meter", 4));
+}
+
+
+#[bench]
+fn test_benchmark_statsdclient_mark_buffered_udp(b: &mut Bencher) {
+    let client = new_buffered_udp_client();
+    b.iter(|| client.mark("some.meter.mark"));
+}
+
+
+#[bench]
 fn test_benchmark_new_counter_obj(b: &mut Bencher) {
-    b.iter(|| {
-        Counter::new("prefix", "some.counter", 5);
-    });
+    b.iter(|| Counter::new("prefix", "some.counter", 5));
 }
 
 #[bench]
 fn test_benchmark_new_timer_obj(b: &mut Bencher) {
-    b.iter(|| {
-        Timer::new("prefix", "some.timer", 5);
-    });
+    b.iter(|| Timer::new("prefix", "some.timer", 5));
 }
 
 
 #[bench]
 fn test_benchmark_new_gauge_obj(b: &mut Bencher) {
-    b.iter(|| {
-        Gauge::new("prefix", "some.gauge", 5);
-    });
+    b.iter(|| Gauge::new("prefix", "some.gauge", 5));
 }
 
 
 #[bench]
 fn test_benchmark_new_meter_obj(b: &mut Bencher) {
-    b.iter(|| {
-        Meter::new("prefix", "some.meter", 5);
-    });
+    b.iter(|| Meter::new("prefix", "some.meter", 5));
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -23,7 +23,8 @@ use ::types::{MetricResult, Counter, Timer, Gauge, Meter, Metric};
 /// by the server receiving them. Examples of counter uses include number
 /// of logins to a system or requests received.
 ///
-/// See the [Statsd spec](https://github.com/b/statsd_spec) for more information.
+/// See the [Statsd spec](https://github.com/b/statsd_spec) for more
+/// information.
 pub trait Counted {
     /// Increment the counter by `1`
     fn incr(&self, key: &str) -> MetricResult<Counter>;
@@ -42,7 +43,8 @@ pub trait Counted {
 /// time. Examples include time taken to render a web page or time taken
 /// for a database call to return.
 ///
-/// See the [Statsd spec](https://github.com/b/statsd_spec) for more information.
+/// See the [Statsd spec](https://github.com/b/statsd_spec) for more
+/// information.
 pub trait Timed {
     /// Record a timing in milliseconds with the given key
     fn time(&self, key: &str, time: u64) -> MetricResult<Timer>;
@@ -55,7 +57,8 @@ pub trait Timed {
 /// by the client. They do not change unless changed by the client. Examples
 /// include things like load average or how many connections are active.
 ///
-/// See the [Statsd spec](https://github.com/b/statsd_spec) for more information.
+/// See the [Statsd spec](https://github.com/b/statsd_spec) for more
+/// information.
 pub trait Gauged {
     /// Record a gauge value with the given key
     fn gauge(&self, key: &str, value: u64) -> MetricResult<Gauge>;
@@ -70,7 +73,8 @@ pub trait Gauged {
 /// things like number of requests handled or number of times something is
 /// flushed to disk.
 ///
-/// See the [Statsd spec](https://github.com/b/statsd_spec) for more information.
+/// See the [Statsd spec](https://github.com/b/statsd_spec) for more
+/// information.
 pub trait Metered {
     /// Record a single metered event with the given key
     fn mark(&self, key: &str) -> MetricResult<Meter>;
@@ -117,6 +121,7 @@ pub trait MetricClient: Counted + Timed + Gauged + Metered {}
 ///
 /// The client uses some implementation of a `MetricSink` to emit the metrics.
 /// In most cases, users will want to use the `UdpMetricSink` implementation.
+#[derive(Debug)]
 pub struct StatsdClient<T: MetricSink> {
     prefix: String,
     sink: T,
@@ -149,6 +154,21 @@ impl<T: MetricSink> StatsdClient<T> {
     /// socket.set_nonblocking(true).unwrap();
     ///
     /// let sink = UdpMetricSink::from(host, socket).unwrap();
+    /// let client = StatsdClient::from_sink(prefix, sink);
+    /// ```
+    ///
+    /// # Buffered UDP Socket Example
+    ///
+    /// ```
+    /// use std::net::UdpSocket;
+    /// use cadence::{StatsdClient, BufferedUdpMetricSink, DEFAULT_PORT};
+    ///
+    /// let prefix = "my.stats";
+    /// let host = ("127.0.0.1", DEFAULT_PORT);
+    ///
+    /// let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+    ///
+    /// let sink = BufferedUdpMetricSink::from(host, socket).unwrap();
     /// let client = StatsdClient::from_sink(prefix, sink);
     /// ```
     pub fn from_sink(prefix: &str, sink: T) -> StatsdClient<T> {

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,0 +1,214 @@
+// Cadence - An extensible Statsd client for Rust!
+//
+// Copyright 2015-2016 TSH Labs
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+use std::io;
+use std::io::{BufWriter, Write};
+use std::net::{SocketAddr, UdpSocket};
+
+
+/// Buffered implementation of the `Write` trait that appends a
+/// trailing line ending string to every input written and only
+/// writes the complete input in a single call to the underlying
+/// writer.
+#[derive(Debug)]
+pub struct MultiLineWriter<T: Write> {
+    written: usize,
+    capacity: usize,
+    inner: BufWriter<T>,
+    line_ending: Vec<u8>,
+}
+
+
+impl<T: Write> MultiLineWriter<T> {
+    /// Create a new buffered `MultiLineWriter` instance that suffixes
+    /// each write with a newline character ('\n').
+    pub fn new(cap: usize, inner: T) -> MultiLineWriter<T> {
+        Self::with_ending(cap, inner, "\n")
+    }
+
+    /// Create a new buffered `MultiLineWriter` instance that suffixes
+    /// each write with the given line ending.
+    pub fn with_ending(cap: usize, inner: T, end: &str) -> MultiLineWriter<T> {
+        MultiLineWriter {
+            written: 0,
+            capacity: cap,
+            inner: BufWriter::with_capacity(cap, inner),
+            line_ending: Vec::from(end.as_bytes()),
+        }
+    }
+}
+
+
+impl<T: Write> Write for MultiLineWriter<T> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let left = self.capacity - self.written;
+
+        if left < buf.len() + self.line_ending.len() {
+            try!(self.flush());
+        }
+
+        if buf.len() > self.capacity {
+            // If the user has given us a value bigger than our buffer
+            // to write, bypass the buffer and write directly to the Write
+            // implementation that our BufWriter is wrapping.
+            let write1 = try!(self.inner.get_mut().write(buf));
+            let write2 = try!(self.inner.get_mut().write(&self.line_ending));
+            Ok(write1 + write2)
+        } else {
+            // Perform the buffered write of user data and the trailing
+            // newlines. Increment the number of bytes written to the
+            // buffer after each write in case the return errors.
+            let write1 = try!(self.inner.write(buf));
+            self.written += write1;
+
+            let write2 = try!(self.inner.write(&self.line_ending));
+            self.written += write2;
+            Ok(write1 + write2)
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        try!(self.inner.flush());
+        self.written = 0;
+        Ok(())
+    }
+}
+
+
+/// Adapter for writing to a UdpSocket via the Write trait
+#[derive(Debug)]
+pub struct UdpWriteAdapter {
+    addr: SocketAddr,
+    socket: UdpSocket,
+}
+
+
+impl UdpWriteAdapter {
+    pub fn new(addr: SocketAddr, socket: UdpSocket) -> UdpWriteAdapter {
+        UdpWriteAdapter {
+            addr: addr,
+            socket: socket
+        }
+    }
+}
+
+
+impl Write for UdpWriteAdapter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.socket.send_to(buf, &self.addr)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::MultiLineWriter;
+
+    use std::str;
+    use std::io::Write;
+
+    #[test]
+    fn test_write_needs_flush() {
+        let mut buffered = MultiLineWriter::new(16, vec![]);
+
+        let write1 = buffered.write("foo:1234|c".as_bytes()).unwrap();
+        let written_after_write1 = buffered.inner.get_ref().len();
+
+        let write2 = buffered.write("baz:56789|c".as_bytes()).unwrap();
+        let written_after_write2 = buffered.inner.get_ref().len();
+
+        let written = str::from_utf8(&buffered.inner.get_ref()).unwrap();
+
+        assert_eq!(11, write1);
+        assert_eq!(0, written_after_write1);
+
+        assert_eq!(12, write2);
+        assert_eq!(11, written_after_write2);
+
+        assert_eq!("foo:1234|c\n", written);
+    }
+
+    #[test]
+    fn test_write_no_flush() {
+        let mut buffered = MultiLineWriter::new(32, vec![]);
+
+        let write1 = buffered.write("abc:3|g".as_bytes()).unwrap();
+        let written_after_write1 = buffered.inner.get_ref().len();
+
+        let write2 = buffered.write("def:4|g".as_bytes()).unwrap();
+        let written_after_write2 = buffered.inner.get_ref().len();
+
+        assert_eq!(8, write1);
+        assert_eq!(0, written_after_write1);
+
+        assert_eq!(8, write2);
+        assert_eq!(0, written_after_write2);
+    }
+
+    #[test]
+    fn test_write_bigger_than_buffer() {
+        let mut buffered = MultiLineWriter::new(16, vec![]);
+
+        let write1 = buffered.write(
+            "some_really_long_metric:456|c".as_bytes()).unwrap();
+        let written_after_write1 = buffered.inner.get_ref().len();
+        let in_buffer_after_write1 = buffered.written;
+
+        let write2 = buffered.write(
+            "abc:4|g".as_bytes()).unwrap();
+        let written_after_write2 = buffered.inner.get_ref().len();
+        let in_buffer_after_write2 = buffered.written;
+
+        assert_eq!(30, write1);
+        assert_eq!(30, written_after_write1);
+        assert_eq!(0, in_buffer_after_write1);
+
+        assert_eq!(8, write2);
+        assert_eq!(30, written_after_write2);
+        assert_eq!(8, in_buffer_after_write2);
+    }
+
+    #[test]
+    fn test_flush_still_buffered() {
+        let mut buffered = MultiLineWriter::new(32, vec![]);
+
+        buffered.write("xyz".as_bytes()).unwrap();
+        buffered.write("abc".as_bytes()).unwrap();
+        let len_after_writes = buffered.inner.get_ref().len();
+
+        buffered.flush().unwrap();
+        let written = str::from_utf8(&buffered.inner.get_ref()).unwrap();
+
+        assert_eq!(0, len_after_writes);
+        assert_eq!("xyz\nabc\n", written);
+    }
+
+    #[test]
+    fn test_buffer_flushed_when_dropped() {
+        let mut buf: Vec<u8> = vec![];
+
+        // Create our writer in a different scope to ensure that the
+        // BufWriter it's using internally is flushed when it goes out
+        // of scope and anything that was buffered gets written out.
+        {
+            let mut writer = MultiLineWriter::new(32, &mut buf);
+            let _r = writer.write("something".as_bytes()).unwrap();
+            assert_eq!(0,  writer.inner.get_ref().len());
+        }
+
+        assert_eq!(10, buf.len());
+        assert_eq!("something\n", str::from_utf8(&buf).unwrap());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,6 +207,46 @@
 //! client.incr("some.event");
 //! ```
 //!
+//! ### Buffered UDP Sink
+//!
+//! While sending a metric over UDP is very fast, the overhead of frequent
+//! network calls can start to add up. This is especially true if you are
+//! writing a high performance application that emits a lot of metrics.
+//!
+//! To make sure that metrics aren't interfering with the performance of
+//! your application, you may want to use a `MetricSink` implentation that
+//! buffers multiple metrics before sending them in a single network
+//! operation. For this, there's `BufferedUdpMetricSink`. An example of
+//! using this sink is given below.
+//!
+//! ``` rust,no_run
+//! use std::net::UdpSocket;
+//! use cadence::prelude::*;
+//! use cadence::{StatsdClient, BufferedUdpMetricSink, DEFAULT_PORT};
+//!
+//! let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+//! socket.set_nonblocking(true).unwrap();
+//!
+//! let host = ("metrics.example.com", DEFAULT_PORT);
+//! let sink = BufferedUdpMetricSink::from(host, socket).unwrap();
+//! let client = StatsdClient::from_sink("my.prefix", sink);
+//!
+//! client.count("my.counter.thing", 29);
+//! client.time("my.service.call", 214);
+//! client.incr("some.event");
+//! ```
+//!
+//! As you can see, using this buffered UDP sink is no more complicated
+//! than using the regular, non-buffered, UDP sink.
+//!
+//! The only downside to this sink is that metrics aren't written to the
+//! Statsd server until the buffer is full. If you have a busy application
+//! that is constantly emitting metrics, this shouldn't be a problem.
+//! However, if your application only occasionally emits metrics, this sink
+//! might result in the metrics being delayed for a little while until the
+//! buffer fills.
+//!
+
 
 
 #[macro_use]
@@ -221,7 +261,7 @@ pub use self::client::{Counted, Timed, Gauged, Metered, MetricClient,
 
 
 pub use self::sinks::{MetricSink, ConsoleMetricSink, LoggingMetricSink,
-                      NopMetricSink, UdpMetricSink};
+                      NopMetricSink, UdpMetricSink, BufferedUdpMetricSink};
 
 
 pub use self::types::{MetricResult, MetricError, ErrorKind, Counter, Timer,
@@ -230,5 +270,6 @@ pub use self::types::{MetricResult, MetricError, ErrorKind, Counter, Timer,
 
 pub mod prelude;
 mod client;
+mod io;
 mod sinks;
 mod types;

--- a/src/sinks.rs
+++ b/src/sinks.rs
@@ -11,9 +11,21 @@
 
 use log::LogLevel;
 use std::io;
+use std::io::Write;
 use std::net::{ToSocketAddrs, SocketAddr, UdpSocket};
+use std::sync::Mutex;
 
+use ::io::{MultiLineWriter, UdpWriteAdapter};
 use ::types::{MetricResult, MetricError, ErrorKind};
+
+
+/// Default size of the buffer for buffered metric sinks. This
+/// is a rather conservative value, picked to make sure the entire
+/// buffer fits in a small UDP packet. Users may want to use a
+/// different value based on the configuration of the network
+/// their application runs in.
+pub const DEFAULT_BUFFER_SIZE: usize = 512;
+
 
 /// Trait for various backends that send Statsd metrics somewhere.
 ///
@@ -45,11 +57,25 @@ use ::types::{MetricResult, MetricError, ErrorKind};
 /// some.meter:8|m
 /// ```
 ///
-/// See the [Statsd spec](https://github.com/b/statsd_spec) for more information.
+/// See the [Statsd spec](https://github.com/b/statsd_spec) for more
+/// information.
 pub trait MetricSink {
     /// Send the Statsd metric using this sink and return the number of bytes
     /// written or an I/O error.
     fn emit(&self, metric: &str) -> io::Result<usize>;
+}
+
+
+/// Attempt to convert anything implementing the `ToSocketAddrs` trait
+/// into a concrete `SocketAddr` instance, returning an `InvalidInput`
+/// error if the address could not be parsed.
+fn get_addr<A: ToSocketAddrs>(addr: A) -> MetricResult<SocketAddr> {
+    match try!(addr.to_socket_addrs()).next() {
+        Some(addr) => Ok(addr),
+        None => Err(MetricError::from(
+            (ErrorKind::InvalidInput, "No socket addresses yielded")
+        )),
+    }
 }
 
 
@@ -58,6 +84,7 @@ pub trait MetricSink {
 /// This is the `MetricSink` that almost all consumers of this library will
 /// want to use. It accepts a UDP socket instance over which to write metrics
 /// and the address of the Statsd server to send packets to.
+#[derive(Debug)]
 pub struct UdpMetricSink {
     sink_addr: SocketAddr,
     socket: UdpSocket,
@@ -108,18 +135,15 @@ impl UdpMetricSink {
     ///
     /// * It is unable to resolve the hostname of the metric server.
     /// * The host address is otherwise unable to be parsed
-    pub fn from<A>(sink_addr: A, socket: UdpSocket) -> MetricResult<UdpMetricSink>
+    pub fn from<A>(sink_addr: A, socket: UdpSocket)
+                   -> MetricResult<UdpMetricSink>
         where A: ToSocketAddrs
     {
-        match try!(sink_addr.to_socket_addrs()).next() {
-            Some(addr) => Ok(UdpMetricSink {
-                sink_addr: addr,
-                socket: socket,
-            }),
-            None => Err(MetricError::from(
-                (ErrorKind::InvalidInput, "No socket addresses yielded")
-            )),
-        }
+        let addr = try!(get_addr(sink_addr));
+        Ok(UdpMetricSink {
+            sink_addr: addr,
+            socket: socket,
+        })
     }
 }
 
@@ -131,9 +155,128 @@ impl MetricSink for UdpMetricSink {
 }
 
 
+/// Implementation of a `MetricSink` that buffers metrics before
+/// sending them to a UDP socket.
+///
+/// Metrics are line buffered, meaning that a trailing "\n" is added
+/// after each metric written to this sink. When the buffer is sufficiently
+/// full, the contents of the buffer are flushed to a UDP socket and then
+/// the metric is written to the buffer. The buffer is also flushed when
+/// this sink is destroyed.
+///
+/// The default size of the buffer is 512 bytes. This is the "safest"
+/// size for a UDP packet according to the Etsy Statsd docs. The
+/// buffer size can be customized using the `with_capacity` method
+/// to create the sink if desired.
+///
+/// If a metric larger than the buffer is emitted, it will be written
+/// directly to the underlying UDP socket, bypassing the buffer.
+#[derive(Debug)]
+pub struct BufferedUdpMetricSink {
+    buffer: Mutex<MultiLineWriter<UdpWriteAdapter>>,
+}
+
+
+impl BufferedUdpMetricSink {
+    /// Construct a new `BufferedUdpMetricSink` instance with a default
+    /// buffer size of 512 bytes.
+    ///
+    /// The address should be the address of the remote metric server to
+    /// emit metrics to over UDP. The socket should already be bound to a
+    /// local address with any desired configuration applied (blocking vs
+    /// non-blocking, timeouts, etc.).
+    ///
+    /// Writes to this sink are automatically suffixed  with a Unix newline
+    /// ('\n') by the sink and stored in a 512 byte buffer until the buffer
+    /// is full or this sink is destroyed, at which point the buffer will be
+    /// flushed.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use std::net::UdpSocket;
+    /// use cadence::{BufferedUdpMetricSink, DEFAULT_PORT};
+    ///
+    /// let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+    /// let host = ("metrics.example.com", DEFAULT_PORT);
+    /// let sink = BufferedUdpMetricSink::from(host, socket);
+    /// ```
+    ///
+    /// # Failures
+    ///
+    /// This method may fail if:
+    ///
+    /// * It is unable to resolve the hostname of the metric server.
+    /// * The host address is otherwise unable to be parsed
+    pub fn from<A>(sink_addr: A, socket: UdpSocket)
+                   -> MetricResult<BufferedUdpMetricSink>
+        where A: ToSocketAddrs
+    {
+        Self::with_capacity(sink_addr, socket, DEFAULT_BUFFER_SIZE)
+    }
+
+    /// Construct a new `BufferedUdpMetricSink` instance with a custom
+    /// buffer size.
+    ///
+    /// The address should be the address of the remote metric server to
+    /// emit metrics to over UDP. The socket should already be bound to a
+    /// local address with any desired configuration applied (blocking vs
+    /// non-blocking, timeouts, etc.).
+    ///
+    /// Writes to this sink are automatically suffixed  with a Unix newline
+    /// ('\n') by the sink and stored in a buffer until the buffer is full
+    /// or this sink is destroyed, at which point the buffer will be flushed.
+    ///
+    /// For guidance on sizing your buffer see the [Statsd docs]
+    /// (https://github.com/etsy/statsd/blob/master/docs/metric_types.md#multi-metric-packets).
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use std::net::UdpSocket;
+    /// use cadence::{BufferedUdpMetricSink, DEFAULT_PORT};
+    ///
+    /// let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+    /// let host = ("metrics.example.com", DEFAULT_PORT);
+    /// let sink = BufferedUdpMetricSink::with_capacity(host, socket, 1432);
+    /// ```
+    ///
+    /// # Failures
+    ///
+    /// This method may fail if:
+    ///
+    /// * It is unable to resolve the hostname of the metric server.
+    /// * The host address is otherwise unable to be parsed
+    pub fn with_capacity<A>(sink_addr: A, socket: UdpSocket, cap: usize)
+                          -> MetricResult<BufferedUdpMetricSink>
+        where A: ToSocketAddrs
+    {
+        let addr = try!(get_addr(sink_addr));
+        Ok(BufferedUdpMetricSink {
+            buffer: Mutex::new(MultiLineWriter::new(
+                cap, UdpWriteAdapter::new(addr, socket)
+            )),
+        })
+    }
+}
+
+
+impl MetricSink for BufferedUdpMetricSink {
+    fn emit(&self, metric: &str) -> io::Result<usize> {
+        // TODO: How do we handle this lock being poisoned? If it
+        // is this will just panic and blow up people's application
+        // which is not great. Is there a way to recreate the mutex
+        // here if it's poisoned via settings a new one in a RefCell?
+        let mut writer = self.buffer.lock().unwrap();
+        writer.write(metric.as_bytes())
+    }
+}
+
+
 /// Implementation of a `MetricSink` that discards all metrics.
 ///
 /// Useful for disabling metric collection or unit tests.
+#[derive(Debug)]
 pub struct NopMetricSink;
 
 
@@ -148,6 +291,7 @@ impl MetricSink for NopMetricSink {
 /// Implementation of a `MetricSink` that emits metrics to the console.
 ///
 /// Metrics are emitted with the `println!` macro.
+#[derive(Debug)]
 pub struct ConsoleMetricSink;
 
 
@@ -164,6 +308,7 @@ impl MetricSink for ConsoleMetricSink {
 /// Metrics are emitted using the `LogLevel` provided at construction with a target
 /// of `cadence::metrics`. Note that the number of bytes written returned by `emit`
 /// does not reflect if the provided log level is high enough to be active.
+#[derive(Debug)]
 pub struct LoggingMetricSink {
     level: LogLevel,
 }
@@ -190,7 +335,20 @@ mod tests {
     use log::LogLevel;
     use std::net::UdpSocket;
 
-    use super::{MetricSink, NopMetricSink, ConsoleMetricSink, LoggingMetricSink, UdpMetricSink};
+    use super::{get_addr, MetricSink, NopMetricSink, ConsoleMetricSink,
+                LoggingMetricSink, UdpMetricSink, BufferedUdpMetricSink};
+
+    #[test]
+    fn test_get_addr_bad_address() {
+        let res = get_addr("asdf");
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_get_addr_valid_address() {
+        let res = get_addr("127.0.0.1:8125");
+        assert!(res.is_ok());
+    }
 
     // Basic smoke / sanity checks to make sure we're getting
     // some expected results from the various sinks. The UDP
@@ -230,4 +388,18 @@ mod tests {
         assert_eq!(7, sink.emit("baz:1|m").unwrap());
     }
 
+    #[test]
+    fn test_buffered_udp_metric_sink() {
+        let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+        // Set the capacity of the buffer such that we know it will
+        // be flush as a response to the metrics we're writing.
+        let sink = BufferedUdpMetricSink::with_capacity(
+            "127.0.0.1:8125", socket, 16).unwrap();
+
+        // Note that we're including an extra byte in the expected
+        // number written since each metric is followed by a '\n' at
+        // the end.
+        assert_eq!(9, sink.emit("foo:54|c").unwrap());
+        assert_eq!(9, sink.emit("foo:67|c").unwrap());
+    }
 }


### PR DESCRIPTION
New MetricSink implementation that buffers metrics sent to it up to a certain
size (user configurable) before sending via a UDP socket. Each metric is written
to a shared (mutex guarded) buffer along with a trailing newline (\n). When the
buffer cannot fit the next metric, it will be flushed.

Metrics that are too large for the buffer (unlikely but possible) will be written
directly to the underlying socket.

Current limitations:

* Mutex poisoning is not handled. It has the potential to panic the thread.
* Metrics are still written to the socket in the calling thread.

Fixes #18