### PR TITLE
Implement Clone trait for StatsdClient and other types

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -121,7 +121,7 @@ pub trait MetricClient: Counted + Timed + Gauged + Metered {}
 ///
 /// The client uses some implementation of a `MetricSink` to emit the metrics.
 /// In most cases, users will want to use the `UdpMetricSink` implementation.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct StatsdClient<T: MetricSink> {
     prefix: String,
     sink: T,

--- a/src/sinks.rs
+++ b/src/sinks.rs
@@ -276,7 +276,7 @@ impl MetricSink for BufferedUdpMetricSink {
 /// Implementation of a `MetricSink` that discards all metrics.
 ///
 /// Useful for disabling metric collection or unit tests.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct NopMetricSink;
 
 
@@ -291,7 +291,7 @@ impl MetricSink for NopMetricSink {
 /// Implementation of a `MetricSink` that emits metrics to the console.
 ///
 /// Metrics are emitted with the `println!` macro.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ConsoleMetricSink;
 
 
@@ -308,7 +308,7 @@ impl MetricSink for ConsoleMetricSink {
 /// Metrics are emitted using the `LogLevel` provided at construction with a target
 /// of `cadence::metrics`. Note that the number of bytes written returned by `emit`
 /// does not reflect if the provided log level is high enough to be active.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct LoggingMetricSink {
     level: LogLevel,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -25,7 +25,7 @@ pub trait Metric {
 /// Counters are simple values incremented or decremented by a client.
 ///
 /// See the `Counted` trait for more information.
-#[derive(PartialEq, Eq, Debug, Hash)]
+#[derive(PartialEq, Eq, Debug, Hash, Clone)]
 pub struct Counter {
     repr: String,
 }
@@ -48,7 +48,7 @@ impl Metric for Counter {
 /// Timers are a positive number of milliseconds between a start and end point.
 ///
 /// See the `Timed` trait for more information.
-#[derive(PartialEq, Eq, Debug, Hash)]
+#[derive(PartialEq, Eq, Debug, Hash, Clone)]
 pub struct Timer {
     repr: String,
 }
@@ -71,7 +71,7 @@ impl Metric for Timer {
 /// Gauges are an instantaneous value determined by the client.
 ///
 /// See the `Gauged` trait for more information.
-#[derive(PartialEq, Eq, Debug, Hash)]
+#[derive(PartialEq, Eq, Debug, Hash, Clone)]
 pub struct Gauge {
     repr: String,
 }
@@ -94,7 +94,7 @@ impl Metric for Gauge {
 /// Meters measure the rate at which events occur as determined by the server.
 ///
 /// See the `Metered` trait for more information.
-#[derive(PartialEq, Eq, Debug, Hash)]
+#[derive(PartialEq, Eq, Debug, Hash, Clone)]
 pub struct Meter {
     repr: String,
 }


### PR DESCRIPTION
Implement the Clone trait for the client, various types, and all sinks
that can be cloned (anything not dealing with a UDP socket). This makes
it easier to potentially clone client instances to be sent between
threads in the future to support an async client.

Fixes #24