### PR TITLE
Create AsyncMetricSink that emits metrics using a thread pool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,11 @@ keywords = ["statsd", "metrics"]
 
 [dependencies]
 log = "0.3"
+threadpool = { version = "1.3.1", optional = true }
+
+[features]
+default = ["threading"]
+threading = ["threadpool"]
 
 [lib]
 name = "cadence"

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -8,7 +8,8 @@ use std::net::UdpSocket;
 
 use cadence::prelude::*;
 use cadence::{DEFAULT_PORT, StatsdClient, Counter, Timer, Gauge, Meter,
-              NopMetricSink, UdpMetricSink, BufferedUdpMetricSink};
+              NopMetricSink, UdpMetricSink, BufferedUdpMetricSink,
+              AsyncMetricSink};
 
 
 fn new_nop_client() -> StatsdClient<NopMetricSink> {
@@ -28,6 +29,15 @@ fn new_buffered_udp_client() -> StatsdClient<BufferedUdpMetricSink> {
     let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
     let sink = BufferedUdpMetricSink::from(host, socket).unwrap();
     StatsdClient::from_sink("test.bench.buffered", sink)
+}
+
+
+fn new_async_buffered_udp_client() -> StatsdClient<AsyncMetricSink<BufferedUdpMetricSink>> {
+    let host = ("127.0.0.1", DEFAULT_PORT);
+    let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+    let sink = BufferedUdpMetricSink::from(host, socket).unwrap();
+    let async = AsyncMetricSink::from(sink);
+    StatsdClient::from_sink("test.bench.buffered", async)
 }
 
 
@@ -174,6 +184,55 @@ fn test_benchmark_statsdclient_meter_buffered_udp(b: &mut Bencher) {
 #[bench]
 fn test_benchmark_statsdclient_mark_buffered_udp(b: &mut Bencher) {
     let client = new_buffered_udp_client();
+    b.iter(|| client.mark("some.meter.mark"));
+}
+
+
+#[bench]
+fn test_benchmark_statsdclient_count_async_buffered_udp(b: &mut Bencher) {
+    let client = new_async_buffered_udp_client();
+    b.iter(|| client.count("some.counter", 4));
+}
+
+
+#[bench]
+fn test_benchmark_statsdclient_incr_async_buffered_udp(b: &mut Bencher) {
+    let client = new_async_buffered_udp_client();
+    b.iter(|| client.incr("some.counter.incr"));
+}
+
+
+#[bench]
+fn test_benchmark_statsdclient_decr_async_buffered_udp(b: &mut Bencher) {
+    let client = new_async_buffered_udp_client();
+    b.iter(|| client.decr("some.counter.decr"));
+}
+
+
+#[bench]
+fn test_benchmark_statsdclient_time_async_buffered_udp(b: &mut Bencher) {
+    let client = new_async_buffered_udp_client();
+    b.iter(|| client.time("some.timer", 4));
+}
+
+
+#[bench]
+fn test_benchmark_statsdclient_gauge_async_buffered_udp(b: &mut Bencher) {
+    let client = new_async_buffered_udp_client();
+    b.iter(|| client.gauge("some.gauge", 4));
+}
+
+
+#[bench]
+fn test_benchmark_statsdclient_meter_async_buffered_udp(b: &mut Bencher) {
+    let client = new_async_buffered_udp_client();
+    b.iter(|| client.meter("some.meter", 4));
+}
+
+
+#[bench]
+fn test_benchmark_statsdclient_mark_async_buffered_udp(b: &mut Bencher) {
+    let client = new_async_buffered_udp_client();
     b.iter(|| client.mark("some.meter.mark"));
 }
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -46,6 +46,7 @@ impl<T: Write> MultiLineWriter<T> {
         }
     }
 
+    #[allow(dead_code)]
     fn get_ref(&self) -> &T {
         self.inner.get_ref()
     }
@@ -84,36 +85,6 @@ impl<T: Write> Write for MultiLineWriter<T> {
         try!(self.inner.flush());
         self.written = 0;
         Ok(())
-    }
-}
-
-
-impl<T> Clone for MultiLineWriter<T> where T: Write + Clone {
-    fn clone(&self) -> Self {
-        // We know this is safe since we did the conversion from &str to
-        // bytes originally. Just go back to a &str here so that we can
-        // use the constructor and not duplicate code.
-        let ending = unsafe {
-            str::from_utf8_unchecked(&self.line_ending)
-        };
-
-        MultiLineWriter::with_ending(
-            self.capacity,
-            self.get_ref().clone(),
-            ending
-        )
-    }
-
-    fn clone_from(&mut self, source: &Self) {
-        self.capacity = source.capacity;
-        // We're creating a new BufWriter to wrap the underlying Write
-        // implementation so we don't care what the source object has
-        // already written, we're buffering in a new instance so we start
-        // from 0 bytes written.
-        self.written = 0;
-        self.inner = BufWriter::with_capacity(
-            self.capacity, source.get_ref().clone());
-        self.line_ending = source.line_ending.clone();
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,87 @@
 //! client.meter("some.value", 5);
 //! ```
 //!
+//! ### Buffered UDP Sink
+//!
+//! While sending a metric over UDP is very fast, the overhead of frequent
+//! network calls can start to add up. This is especially true if you are
+//! writing a high performance application that emits a lot of metrics.
+//!
+//! To make sure that metrics aren't interfering with the performance of
+//! your application, you may want to use a `MetricSink` implentation that
+//! buffers multiple metrics before sending them in a single network
+//! operation. For this, there's `BufferedUdpMetricSink`. An example of
+//! using this sink is given below.
+//!
+//! ``` rust,no_run
+//! use std::net::UdpSocket;
+//! use cadence::prelude::*;
+//! use cadence::{StatsdClient, BufferedUdpMetricSink, DEFAULT_PORT};
+//!
+//! let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+//! socket.set_nonblocking(true).unwrap();
+//!
+//! let host = ("metrics.example.com", DEFAULT_PORT);
+//! let sink = BufferedUdpMetricSink::from(host, socket).unwrap();
+//! let client = StatsdClient::from_sink("my.prefix", sink);
+//!
+//! client.count("my.counter.thing", 29);
+//! client.time("my.service.call", 214);
+//! client.incr("some.event");
+//! ```
+//!
+//! As you can see, using this buffered UDP sink is no more complicated
+//! than using the regular, non-buffered, UDP sink.
+//!
+//! The only downside to this sink is that metrics aren't written to the
+//! Statsd server until the buffer is full. If you have a busy application
+//! that is constantly emitting metrics, this shouldn't be a problem.
+//! However, if your application only occasionally emits metrics, this sink
+//! might result in the metrics being delayed for a little while until the
+//! buffer fills.
+//!
+//! ### Asynchronous Metric Sink
+//!
+//! To make sure emitting metrics doesn't interfere with the performance
+//! of your application (even though emitting metrics is generally quite
+//! fast), it's probably a good idea to make sure metrics are emitted in
+//! in a different thread than your application thread.
+//!
+//! To allow you do this, there is `AsyncMetricSink`. This sink allows you
+//! to wrap any other metric sink and send metrics using a thread pool,
+//! asynchronously from the flow of your application.
+//!
+//! The requirements for the wrapped metric sink are that it is thread
+//! safe, meaning that it implements the `Send` and `Sync` traits.
+//! Additionally, the wrapped sink should implement the `Clone` trait since
+//! this is how the `AsyncMetricSink` is designed to be shared between
+//! threads (see the source code for the `AsyncMetricSink` for more info).
+//! If you're using the `AsyncMetricSink` with another sink from
+//! Cadence, you don't need to worry: they are all thread safe and implement
+//! the `Clone` trait.
+//!
+//! An example of using the `AsyncMetricSink` to wrap a buffered UDP
+//! metric sink is given below.
+//!
+//! ``` rust,no_run
+//! use std::net::UdpSocket;
+//! use cadence::prelude::*;
+//! use cadence::{StatsdClient, AsyncMetricSink, BufferedUdpMetricSink,
+//!               DEFAULT_PORT};
+//!
+//! let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+//! socket.set_nonblocking(true).unwrap();
+//!
+//! let host = ("metrics.example.com", DEFAULT_PORT);
+//! let udp_sink = BufferedUdpMetricSink::from(host, socket).unwrap();
+//! let async_sink = AsyncMetricSink::from(udp_sink);
+//! let client = StatsdClient::from_sink("my.prefix", async_sink);
+//!
+//! client.count("my.counter.thing", 29);
+//! client.time("my.service.call", 214);
+//! client.incr("some.event");
+//! ```
+//!
 //! ### Counted, Timed, Gauged, Metered, and MetricClient Traits
 //!
 //! Each of the methods that the Cadence `StatsdClient` struct uses to send
@@ -149,14 +230,13 @@
 //!
 //! ### Custom Metric Sinks
 //!
-//! The Cadence `StatsdClient` uses implementations of the `MetricSink` trait
-//! to send metrics to a metric server. Most users of the Candence library
-//! probably want to use the `UdpMetricSink` implementation. This is the way
-//! people typically interact with a Statsd server, sending packets over UDP.
+//! The Cadence `StatsdClient` uses implementations of the `MetricSink`
+//! trait to send metrics to a metric server. Most users of the Candence
+//! library probably want to use the `AsyncMetricSink` wrapping an instance
+//! of the `BufferedMetricSink`.
 //!
-//! However, maybe you'd like to do something custom: use a thread pool,
-//! send multiple metrics at the same time, or something else. An example
-//! of creating a custom sink is below.
+//! However, maybe you want to do something not covered by an existing sink.
+//! An example of creating a custom sink is below.
 //!
 //! ``` rust,no_run
 //! use std::io;
@@ -207,50 +287,11 @@
 //! client.incr("some.event");
 //! ```
 //!
-//! ### Buffered UDP Sink
-//!
-//! While sending a metric over UDP is very fast, the overhead of frequent
-//! network calls can start to add up. This is especially true if you are
-//! writing a high performance application that emits a lot of metrics.
-//!
-//! To make sure that metrics aren't interfering with the performance of
-//! your application, you may want to use a `MetricSink` implentation that
-//! buffers multiple metrics before sending them in a single network
-//! operation. For this, there's `BufferedUdpMetricSink`. An example of
-//! using this sink is given below.
-//!
-//! ``` rust,no_run
-//! use std::net::UdpSocket;
-//! use cadence::prelude::*;
-//! use cadence::{StatsdClient, BufferedUdpMetricSink, DEFAULT_PORT};
-//!
-//! let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
-//! socket.set_nonblocking(true).unwrap();
-//!
-//! let host = ("metrics.example.com", DEFAULT_PORT);
-//! let sink = BufferedUdpMetricSink::from(host, socket).unwrap();
-//! let client = StatsdClient::from_sink("my.prefix", sink);
-//!
-//! client.count("my.counter.thing", 29);
-//! client.time("my.service.call", 214);
-//! client.incr("some.event");
-//! ```
-//!
-//! As you can see, using this buffered UDP sink is no more complicated
-//! than using the regular, non-buffered, UDP sink.
-//!
-//! The only downside to this sink is that metrics aren't written to the
-//! Statsd server until the buffer is full. If you have a busy application
-//! that is constantly emitting metrics, this shouldn't be a problem.
-//! However, if your application only occasionally emits metrics, this sink
-//! might result in the metrics being delayed for a little while until the
-//! buffer fills.
-//!
-
 
 
 #[macro_use]
 extern crate log;
+extern crate threadpool;
 
 
 pub const DEFAULT_PORT: u16 = 8125;
@@ -261,7 +302,8 @@ pub use self::client::{Counted, Timed, Gauged, Metered, MetricClient,
 
 
 pub use self::sinks::{MetricSink, ConsoleMetricSink, LoggingMetricSink,
-                      NopMetricSink, UdpMetricSink, BufferedUdpMetricSink};
+                      NopMetricSink, UdpMetricSink, BufferedUdpMetricSink,
+                      AsyncMetricSink};
 
 
 pub use self::types::{MetricResult, MetricError, ErrorKind, Counter, Timer,


### PR DESCRIPTION
Create MetricSink implementation that wraps another metric sink to
emit metrics using worker threads in a thread pool.

As part of making the AsyncMetricSink easy to share between threads,
all sinks now implement reasonable `Clone` behavior. This means for
the UDP sinks that the underlying sockets (or mutex / buffers) are
wrapped in an Arc (Atomic reference count) instance. This allows
the same socket to be shared between threads and still properly
cleaned up.

Fixes #23