### PR TITLE
Remove the generic type from StatsdClient

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@
   switch to `QueuingMetricSink` instead. `QueuingMetricSink` has similar performance,
   emits metrics asynchronously in another thread, and has a more ergonomic signature
   (not requiring a generic parameter for the wrapped sink).
+* **Breaking change** - Remove the generic parameter `T` from the `StatsdClient` per
+  [#45](https://github.com/tshlabs/cadence/issues/45). Instead of requiring all users
+  of the client to care about the `MetricSink` implementation, put it behind an `Arc`
+  pointer in the client and remove the type `T` from the signature. This makes the
+  client easier to use and share between threads.
 
 ## [v0.10.0](https://github.com/tshlabs/cadence/tree/0.10.0) - 2017-01-08
 * **Breaking change** - Remove deprecated `ConsoleMetricSink` and `LoggingMetricSink`

--- a/README.md
+++ b/README.md
@@ -74,8 +74,7 @@ use cadence::{StatsdClient, UdpMetricSink, DEFAULT_PORT};
 // the client when you use it for real in your application. We're just
 // using .unwrap() here since this is an example!
 let host = ("metrics.example.com", DEFAULT_PORT);
-let client = StatsdClient::<UdpMetricSink>::from_udp_host(
-    "my.metrics", host).unwrap();
+let client = StatsdClient::from_udp_host("my.metrics", host).unwrap();
 
 // Emit metrics!
 client.incr("some.counter");
@@ -209,8 +208,7 @@ impl MyUserDao {
 
 // Create a new Statsd client that writes to "metrics.example.com"
 let host = ("metrics.example.com", DEFAULT_PORT);
-let metrics = StatsdClient::<UdpMetricSink>::from_udp_host(
-    "counter.example", host).unwrap();
+let metrics = StatsdClient::from_udp_host("counter.example", host).unwrap();
 
 // Create a new instance of the DAO that will use the client
 let dao = MyUserDao::new(metrics);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,8 +76,7 @@
 //! // the client when you use it for real in your application. We're just
 //! // using .unwrap() here since this is an example!
 //! let host = ("metrics.example.com", DEFAULT_PORT);
-//! let client = StatsdClient::<UdpMetricSink>::from_udp_host(
-//!     "my.metrics", host).unwrap();
+//! let client = StatsdClient::from_udp_host("my.metrics", host).unwrap();
 //!
 //! // Emit metrics!
 //! client.incr("some.counter");
@@ -215,8 +214,7 @@
 //!
 //! // Create a new Statsd client that writes to "metrics.example.com"
 //! let host = ("metrics.example.com", DEFAULT_PORT);
-//! let metrics = StatsdClient::<UdpMetricSink>::from_udp_host(
-//!     "counter.example", host).unwrap();
+//! let metrics = StatsdClient::from_udp_host("counter.example", host).unwrap();
 //!
 //! // Create a new instance of the DAO that will use the client
 //! let dao = MyUserDao::new(metrics);

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -6,25 +6,23 @@ use std::time::Duration;
 use std::sync::Arc;
 
 use cadence::prelude::*;
-use cadence::{DEFAULT_PORT, NopMetricSink, UdpMetricSink,
-              BufferedUdpMetricSink, MetricSink, StatsdClient,
-              QueuingMetricSink, Counter, Timer, Gauge, Meter,
-              Histogram};
+use cadence::{DEFAULT_PORT, NopMetricSink, BufferedUdpMetricSink,
+              StatsdClient, QueuingMetricSink, Counter, Timer, Gauge,
+              Meter, Histogram};
 
 
-fn new_nop_client(prefix: &str) -> StatsdClient<NopMetricSink> {
+fn new_nop_client(prefix: &str) -> StatsdClient {
     StatsdClient::from_sink(prefix, NopMetricSink)
 }
 
 
-fn new_udp_client(prefix: &str) -> StatsdClient<UdpMetricSink> {
+fn new_udp_client(prefix: &str) -> StatsdClient {
     let addr = ("127.0.0.1", DEFAULT_PORT);
-    StatsdClient::<UdpMetricSink>::from_udp_host(prefix, addr).unwrap()
+    StatsdClient::from_udp_host(prefix, addr).unwrap()
 }
 
 
-fn new_buffered_udp_client(prefix: &str)
-                           -> StatsdClient<BufferedUdpMetricSink> {
+fn new_buffered_udp_client(prefix: &str) -> StatsdClient {
     let host = ("127.0.0.1", DEFAULT_PORT);
     let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
     let sink = BufferedUdpMetricSink::from(host, socket).unwrap();
@@ -32,7 +30,7 @@ fn new_buffered_udp_client(prefix: &str)
 }
 
 
-fn new_queuing_buffered_udp_client(prefix: &str) -> StatsdClient<QueuingMetricSink> {
+fn new_queuing_buffered_udp_client(prefix: &str) -> StatsdClient {
     let host = ("127.0.0.1", DEFAULT_PORT);
     let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
     let sink = BufferedUdpMetricSink::from(host, socket).unwrap();
@@ -161,10 +159,7 @@ fn test_statsd_client_queuing_buffered_udp_sink_many_threaded() {
 }
 
 
-fn run_arc_threaded_test<T>(
-    client: StatsdClient<T>, num_threads: u64, iterations: u64) -> ()
-    where T: 'static + MetricSink + Sync + Send
-{
+fn run_arc_threaded_test(client: StatsdClient, num_threads: u64, iterations: u64) {
     let shared_client = Arc::new(client);
 
     let threads: Vec<_> = (0..num_threads).map(|_| {


### PR DESCRIPTION
Remove the generic type `<T: MetricSink>` from the StatsdClient to make it more
ergonomic to use.

Prior to this, the easiest way to use the client was to put it behind a pointer
of some kind and reference it like `Box<MetricClient>` or
`Arc<MetricClient + Sync + Send>`. This is still possible but is now not required.
Users of the client may simply refer to it directly without needing to include
the concrete type of the `MetricSink`: `fn foo(some_param: StatsdClient) {}`

This commit also introduces some documentation for the `StatsdClient` that
describes the various ways this client can be shared between multiple threads.

Fixes #45