### PR TITLE
Add new `time_duration` method to `Timed` trait

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v0.12.0](https://github.com/tshlabs/cadence/tree/0.12.0) - ????-??-??
+* Add new `time_duration` method to `Timed` trait per
+  [#48](https://github.com/tshlabs/cadence/issues/48). This allows users to record
+  timings using the `Duration` struct from the standard library.
+
 ## [v0.11.0](https://github.com/tshlabs/cadence/tree/0.11.0) - 2017-01-18
 * **Breaking change** - Remove deprecated `AsyncMetricSink` per
   [#47](https://github.com/tshlabs/cadence/issues/47). Users are encouraged to
@@ -11,7 +16,7 @@
   of the client to care about the `MetricSink` implementation, put it behind an `Arc`
   pointer in the client and remove the type `T` from the signature. This makes the
   client easier to use and share between threads.
-* Remove use of `Arc` inside various sinks per [#35](https://github.com/tshlabs/cadence/issues/45).
+* Remove use of `Arc` inside various sinks per [#35](https://github.com/tshlabs/cadence/issues/35).
 
 ## [v0.10.0](https://github.com/tshlabs/cadence/tree/0.10.0) - 2017-01-08
 * **Breaking change** - Remove deprecated `ConsoleMetricSink` and `LoggingMetricSink`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ crossbeam = "0.2.10"
 [lib]
 name = "cadence"
 path = "src/lib.rs"
+
+[badges]
+travis-ci = { repository = "tshlabs/cadence" }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -71,6 +71,14 @@ fn test_statsd_client_time() {
 
 
 #[test]
+fn test_statsd_client_time_duration() {
+    let client = new_nop_client("client.test");
+    let expected = Timer::new("client.test", "timer.key", 35);
+    assert_eq!(expected, client.time_duration("timer.key", Duration::from_millis(35)).unwrap());
+}
+
+
+#[test]
 fn test_statsd_client_gauge() {
     let client = new_nop_client("client.test");
     let expected = Gauge::new("client.test", "gauge.key", 5);


### PR DESCRIPTION
Add a new method for recording timings using std::time::Duration
instead of a u64 of milliseconds. The duration is converted to the
number of milliseconds before being sent to the sink. Any integer
overflow will cause an error to be returned.

Fixes #48