### PR TITLE
initial support for datadog style tags

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -45,9 +45,33 @@ fn test_benchmark_statsdclient_nop(b: &mut Bencher) {
 
 
 #[bench]
+fn test_benchmark_statsdclient_nop_with_tags(b: &mut Bencher) {
+    let client = new_nop_client();
+    b.iter(|| {
+        let _ = client.count_with_tags("some.counter", 4)
+            .with_tag("host", "app21.example.com")
+            .with_tag("bucket", "3")
+            .send();
+    });
+}
+
+
+#[bench]
 fn test_benchmark_statsdclient_udp(b: &mut Bencher) {
     let client = new_udp_client();
     b.iter(|| client.count("some.counter", 4));
+}
+
+
+#[bench]
+fn test_benchmark_statsdclient_udp_with_tags(b: &mut Bencher) {
+    let client = new_udp_client();
+    b.iter(|| {
+        let _ = client.count_with_tags("some.counter", 4)
+            .with_tag("host", "fs03.example.com")
+            .with_tag("version", "123")
+            .send();
+    });
 }
 
 
@@ -59,9 +83,33 @@ fn test_benchmark_statsdclient_buffered_udp(b: &mut Bencher) {
 
 
 #[bench]
+fn test_benchmark_statsdclient_buffered_udp_with_tags(b: &mut Bencher) {
+    let client = new_buffered_udp_client();
+    b.iter(|| {
+        let _ = client.count_with_tags("some.counter", 4)
+            .with_tag("user-type", "authenticated")
+            .with_tag("bucket", "42")
+            .send();
+    });
+}
+
+
+#[bench]
 fn test_benchmark_statsdclient_queuing_nop(b: &mut Bencher) {
     let client = new_queuing_nop_client();
     b.iter(|| client.count("some.counter", 4));
+}
+
+
+#[bench]
+fn test_benchmark_statsdclient_queuing_nop_with_tags(b: &mut Bencher) {
+    let client = new_queuing_nop_client();
+    b.iter(|| {
+        let _ = client.count_with_tags("some.counter", 4)
+            .with_tag("host", "web32.example.com")
+            .with_tag("platform", "ng")
+            .send();
+    });
 }
 
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,0 +1,130 @@
+// Cadence - An extensible Statsd client for Rust!
+//
+// Copyright 2018 Philip Jenvey <pjenvey@mozilla.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use client::StatsdClient;
+use types::{Metric, MetricResult};
+
+#[derive(Clone)]
+pub struct MetricBuilder<'t, 'c, T>
+where
+    T: Metric,
+{
+    metric: T,
+    tags: Option<Vec<(Option<&'t str>, &'t str)>>,
+    client: &'c StatsdClient,
+}
+
+impl<'t, 'c, T> MetricBuilder<'t, 'c, T>
+where
+    T: Metric,
+{
+    pub fn new(metric: T, client: &'c StatsdClient) -> Self {
+        MetricBuilder {
+            metric: metric,
+            tags: None,
+            client: client,
+        }
+    }
+
+    pub fn with_tag(&mut self, key: &'t str, value: &'t str) -> &mut Self {
+        self.tags
+            .get_or_insert_with(|| Vec::new())
+            .push((Some(key), value));
+        self
+    }
+
+    pub fn with_tag_value(&mut self, value: &'t str) -> &mut Self {
+        self.tags
+            .get_or_insert_with(|| Vec::new())
+            .push((None, value));
+        self
+    }
+
+    fn build(&self) -> String {
+        let mut metric_string = self.metric.as_metric_str().to_string();
+        if let Some(tags) = self.tags.as_ref() {
+            push_datadog_tags(&mut metric_string, tags);
+        }
+        metric_string
+    }
+
+    pub fn send(&self) -> MetricResult<()> {
+        let metric = MetricFromBuilder { repr: self.build() };
+        self.client.send_metric(&metric)
+    }
+}
+
+struct MetricFromBuilder {
+    repr: String,
+}
+
+impl Metric for MetricFromBuilder {
+    fn as_metric_str(&self) -> &str {
+        &self.repr
+    }
+}
+
+fn push_datadog_tags(metric: &mut String, tags: &[(Option<&str>, &str)]) {
+    // XXX: could return an Error if there's any empty strings
+    let kv_size: usize = tags.iter()
+        .map(|tag| {
+            tag.0.map_or(0, |k| k.len() + 1) // +1 for : separator
+             + tag.1.len()
+        })
+        .sum();
+
+    // reserve enough space for prefix, tags/: separators and commas
+    let prefix = "#|";
+    let tags_size = prefix.len() + kv_size + tags.len() - 1;
+    metric.reserve(tags_size);
+
+    metric.push_str(prefix);
+    for (i, &(key, value)) in tags.iter().enumerate() {
+        if i > 0 {
+            metric.push(',');
+        }
+        if let Some(key) = key {
+            metric.push_str(key);
+            metric.push(':');
+        }
+        metric.push_str(value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::push_datadog_tags;
+
+    #[test]
+    fn test_push_datadog_tags() {
+        let metric_str = "some.counter:1|c";
+
+        let mut m = metric_str.to_string();
+        push_datadog_tags(&mut m, &vec![(Some("host"), "app01.example.com")]);
+        assert_eq!(m, format!("{}#|host:app01.example.com", metric_str));
+
+        let mut m = metric_str.to_string();
+        push_datadog_tags(
+            &mut m,
+            &vec![
+                (Some("host"), "app01.example.com"),
+                (Some("bucket"), "A"),
+                (None, "file-server"),
+            ],
+        );
+        assert_eq!(
+            m,
+            format!(
+                "{}#|host:app01.example.com,bucket:A,file-server",
+                metric_str
+            )
+        );
+    }
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -188,7 +188,7 @@ fn push_datadog_tags(metric: &mut String, tags: &[(Option<&str>, &str)]) {
         .sum();
 
     // reserve enough space for prefix, tags/: separators and commas
-    let prefix = "#|";
+    let prefix = "|#";
     let tags_size = prefix.len() + kv_size + tags.len() - 1;
     metric.reserve(tags_size);
 
@@ -215,7 +215,7 @@ mod tests {
 
         let mut m = metric_str.to_string();
         push_datadog_tags(&mut m, &vec![(Some("host"), "app01.example.com")]);
-        assert_eq!(m, format!("{}#|host:app01.example.com", metric_str));
+        assert_eq!(m, format!("{}|#host:app01.example.com", metric_str));
 
         let mut m = metric_str.to_string();
         push_datadog_tags(
@@ -229,7 +229,7 @@ mod tests {
         assert_eq!(
             m,
             format!(
-                "{}#|host:app01.example.com,bucket:A,file-server",
+                "{}|#host:app01.example.com,bucket:A,file-server",
                 metric_str
             )
         );

--- a/src/client.rs
+++ b/src/client.rs
@@ -34,14 +34,23 @@ use ::types::{MetricResult, MetricError, ErrorKind, Counter, Timer, Gauge,
 pub trait Counted {
     /// Increment the counter by `1`
     fn incr(&self, key: &str) -> MetricResult<Counter>;
+
+    /// Increment the counter by `1` and return a `MetricBuilder` that can
+    /// be used to add tags to the metric.
     fn incr_with_tags<'a>(&'a self, key: &'a str) -> MetricBuilder<Counter>;
 
     /// Decrement the counter by `1`
     fn decr(&self, key: &str) -> MetricResult<Counter>;
+
+    /// Decrement the counter by `1` and return a `MetricBuilder that can
+    /// be used to add tags to the metric.
     fn decr_with_tags<'a>(&'a self, key: &'a str) -> MetricBuilder<Counter>;
 
     /// Increment or decrement the counter by the given amount
     fn count(&self, key: &str, count: i64) -> MetricResult<Counter>;
+
+    /// Increment or decrement the counter by the given amount and return
+    /// a `MetricBuilder` that can be used to add tags to the metric.
     fn count_with_tags<'a>(&'a self, key: &'a str, count: i64) -> MetricBuilder<Counter>;
 }
 
@@ -57,6 +66,9 @@ pub trait Counted {
 pub trait Timed {
     /// Record a timing in milliseconds with the given key
     fn time(&self, key: &str, time: u64) -> MetricResult<Timer>;
+
+    /// Record a timing in milliseconds with the given key and return a
+    /// `MetricBuilder` that can be used to add tags to the metric.
     fn time_with_tags<'a>(&'a self, key: &'a str, time: u64) -> MetricBuilder<Timer>;
 
     /// Record a timing in milliseconds with the given key
@@ -64,6 +76,13 @@ pub trait Timed {
     /// The duration will be truncated to millisecond precision. If the
     /// duration cannot be represented as a `u64` an error will be returned.
     fn time_duration(&self, key: &str, duration: Duration) -> MetricResult<Timer>;
+
+    /// Record a timing in milliseconds with the given key and return a
+    /// `MetricBuilder` that can be used to add tags to the metric.
+    ///
+    /// The duration will be truncated to millisecond precision. If the
+    /// duration cannot be represented as a `u64` an error will be deferred
+    /// and returned when `MetricBuilder::send()` is called.
     fn time_duration_with_tags<'a>(
         &'a self,
         key: &'a str,
@@ -83,6 +102,9 @@ pub trait Timed {
 pub trait Gauged {
     /// Record a gauge value with the given key
     fn gauge(&self, key: &str, value: u64) -> MetricResult<Gauge>;
+
+    /// Record a gauge value with the given key and return a `MetricBuilder`
+    /// that can be used to add tags to the metric.
     fn gauge_with_tags<'a>(&'a self, key: &'a str, value: u64) -> MetricBuilder<Gauge>;
 }
 
@@ -100,10 +122,16 @@ pub trait Gauged {
 pub trait Metered {
     /// Record a single metered event with the given key
     fn mark(&self, key: &str) -> MetricResult<Meter>;
+
+    /// Record a single metered event with the given key and return a
+    /// `MetricBuilder` that can be used to add tags to the metric.
     fn mark_with_tags<'a>(&'a self, key: &'a str) -> MetricBuilder<Meter>;
 
     /// Record a meter value with the given key
     fn meter(&self, key: &str, value: u64) -> MetricResult<Meter>;
+
+    /// Record a meter value with the given key and return a `MetricBuilder`
+    /// that can be used to add tags to the metric.
     fn meter_with_tags<'a>(&'a self, key: &'a str, value: u64) -> MetricBuilder<Meter>;
 }
 
@@ -122,6 +150,9 @@ pub trait Metered {
 pub trait Histogrammed {
     /// Record a single histogram value with the given key
     fn histogram(&self, key: &str, value: u64) -> MetricResult<Histogram>;
+
+    /// Record a single histogram value with the given key and return a
+    /// `MetricBuilder` that can be used to add tags to the metric.
     fn histogram_with_tags<'a>(&'a self, key: &'a str, value: u64) -> MetricBuilder<Histogram>;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,24 +286,20 @@
 //! ```
 //!
 
-
 extern crate crossbeam;
-
 
 pub const DEFAULT_PORT: u16 = 8125;
 
+pub use self::builder::MetricBuilder;
 
 pub use self::client::{Counted, Timed, Gauged, Metered, Histogrammed,
                        MetricClient, StatsdClient};
 
-
 pub use self::sinks::{MetricSink, NopMetricSink, UdpMetricSink,
                       BufferedUdpMetricSink, QueuingMetricSink};
 
-
 pub use self::types::{MetricResult, MetricError, ErrorKind, Counter, Timer,
                       Gauge, Meter, Histogram};
-
 
 pub mod prelude;
 mod builder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,6 +306,7 @@ pub use self::types::{MetricResult, MetricError, ErrorKind, Counter, Timer,
 
 
 pub mod prelude;
+mod builder;
 mod client;
 mod io;
 mod sinks;

--- a/src/sinks/udp.rs
+++ b/src/sinks/udp.rs
@@ -194,8 +194,8 @@ impl BufferedUdpMetricSink {
     /// ('\n') by the sink and stored in a buffer until the buffer is full
     /// or this sink is destroyed, at which point the buffer will be flushed.
     ///
-    /// For guidance on sizing your buffer see the [Statsd docs]
-    /// (https://github.com/etsy/statsd/blob/master/docs/metric_types.md#multi-metric-packets).
+    /// For guidance on sizing your buffer see the
+    /// [Statsd docs](https://github.com/etsy/statsd/blob/master/docs/metric_types.md#multi-metric-packets).
     ///
     /// # Example
     ///

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,6 +13,7 @@ use std::error;
 use std::fmt;
 use std::io;
 
+use ::builder::MetricFormatter;
 
 /// Trait for metrics to expose Statsd metric string slice representation.
 ///
@@ -33,10 +34,15 @@ pub struct Counter {
 
 impl Counter {
     pub fn new(prefix: &str, key: &str, count: i64) -> Counter {
-        Counter { repr: format!("{}.{}:{}|c", prefix, key, count) }
+        MetricFormatter::counter(prefix, key, count).build()
     }
 }
 
+impl From<String> for Counter {
+    fn from(s: String) -> Self {
+        Counter { repr: s }
+    }
+}
 
 impl Metric for Counter {
     fn as_metric_str(&self) -> &str {
@@ -58,10 +64,15 @@ pub struct Timer {
 
 impl Timer {
     pub fn new(prefix: &str, key: &str, time: u64) -> Timer {
-        Timer { repr: format!("{}.{}:{}|ms", prefix, key, time) }
+        MetricFormatter::timer(prefix, key, time).build()
     }
 }
 
+impl From<String> for Timer {
+    fn from(s: String) -> Self {
+        Timer { repr: s }
+    }
+}
 
 impl Metric for Timer {
     fn as_metric_str(&self) -> &str {
@@ -81,10 +92,15 @@ pub struct Gauge {
 
 impl Gauge {
     pub fn new(prefix: &str, key: &str, value: u64) -> Gauge {
-        Gauge { repr: format!("{}.{}:{}|g", prefix, key, value) }
+        MetricFormatter::gauge(prefix, key, value).build()
     }
 }
 
+impl From<String> for Gauge {
+    fn from(s: String) -> Self {
+        Gauge { repr: s }
+    }
+}
 
 impl Metric for Gauge {
     fn as_metric_str(&self) -> &str {
@@ -104,10 +120,15 @@ pub struct Meter {
 
 impl Meter {
     pub fn new(prefix: &str, key: &str, value: u64) -> Meter {
-        Meter { repr: format!("{}.{}:{}|m", prefix, key, value) }
+        MetricFormatter::meter(prefix, key, value).build()
     }
 }
 
+impl From<String> for Meter {
+    fn from(s: String) -> Self {
+        Meter { repr: s }
+    }
+}
 
 impl Metric for Meter {
     fn as_metric_str(&self) -> &str {
@@ -131,10 +152,15 @@ pub struct Histogram {
 
 impl Histogram {
     pub fn new(prefix: &str, key: &str, value: u64) -> Histogram {
-        Histogram { repr: format!("{}.{}:{}|h", prefix, key, value) }
+        MetricFormatter::histogram(prefix, key, value).build()
     }
 }
 
+impl From<String> for Histogram {
+    fn from(s: String) -> Self {
+        Histogram { repr: s }
+    }
+}
 
 impl Metric for Histogram {
     fn as_metric_str(&self) -> &str {


### PR DESCRIPTION
This isn't ready to merge but here's some initial legwork for #41. I'll note:

- MetricBuilder as a trait isn't so straightforward as the *_with_tags trait methods can't return traits (can't use impl Trait). They'd need to return a boxed MetricBuilder or possibly an associated type

- Metric::as_metric_str probably needs to be rethought along with a configurable formatting layer, especially if you want to keep allocations down. MetricFromBuilder's pretty silly

- MetricBuilder should handle (probably in a deferred way) Errors (e.g. time_duration_with_tags)