### PR TITLE
Optionally send metrics from MetricBuilder quietly (no result)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v0.14.0](https://github.com/tshlabs/cadence/tree/0.14.0) - 2018-??-??
+* **Breaking change** - Rename the `MetricBuilder::send()` method to
+  `MetricBuilder::try_send()` and create a new `.send()` method that discards
+  successful results and invokes a custom handler for error results. Handlers
+  can be set by using the `StatsdClient::from_sink_with_handler` constructor.
+  Per [#65](https://github.com/tshlabs/cadence/issues/65).
+
 ## [v0.13.2](https://github.com/tshlabs/cadence/tree/0.13.2) - 2018-03-13
 * Warn when `MetricBuilder` instances aren't used when adding tags to metrics
   per [#63](https://github.com/tshlabs/cadence/issues/63).

--- a/README.md
+++ b/README.md
@@ -243,6 +243,36 @@ match dao.get_user_by_id(123) {
 };
 ```
 
+### Quiet Metric Sending and Error Handling
+
+When sending metrics sometimes you don't really care about the `Result` of
+trying to send it or maybe you just don't want to deal with it inline with
+the rest of your code. In order to handle this, Cadence allows you to set a
+default error handler. This handler is invoked when there are errors sending
+metrics so that the calling code doesn't have to deal with them.
+
+An example of configuring an error handler and an example of when it might
+be invoked is given below.
+
+``` rust,no_run
+use cadence::prelude::*;
+use cadence::{MetricError, StatsdClient, NopMetricSink};
+
+fn my_error_handler(err: MetricError) {
+    println!("Metric error! {}", err);
+}
+
+let client = StatsdClient::builder("prefix", NopMetricSink)
+    .with_error_handler(my_error_handler)
+    .build();
+
+// When sending metrics via the `MetricBuilder` used for assembling tags,
+// callers may opt into sending metrics quietly via the `.send()` method
+// as opposed to the `.try_send()` method
+client.count_with_tags("some.counter", 42)
+    .with_tag("region", "us-east-2")
+    .send();
+```
 
 ### Custom Metric Sinks
 

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -41,7 +41,7 @@ fn test_benchmark_statsdclient_nop(b: &mut Bencher) {
 fn test_benchmark_statsdclient_nop_with_tags(b: &mut Bencher) {
     let client = new_nop_client();
     b.iter(|| {
-        let _ = client
+        client
             .count_with_tags("some.counter", 4)
             .with_tag("host", "app21.example.com")
             .with_tag("bucket", "3")
@@ -59,7 +59,7 @@ fn test_benchmark_statsdclient_udp(b: &mut Bencher) {
 fn test_benchmark_statsdclient_udp_with_tags(b: &mut Bencher) {
     let client = new_udp_client();
     b.iter(|| {
-        let _ = client
+        client
             .count_with_tags("some.counter", 4)
             .with_tag("host", "fs03.example.com")
             .with_tag("version", "123")
@@ -77,7 +77,7 @@ fn test_benchmark_statsdclient_buffered_udp(b: &mut Bencher) {
 fn test_benchmark_statsdclient_buffered_udp_with_tags(b: &mut Bencher) {
     let client = new_buffered_udp_client();
     b.iter(|| {
-        let _ = client
+        client
             .count_with_tags("some.counter", 4)
             .with_tag("user-type", "authenticated")
             .with_tag("bucket", "42")
@@ -95,7 +95,7 @@ fn test_benchmark_statsdclient_queuing_nop(b: &mut Bencher) {
 fn test_benchmark_statsdclient_queuing_nop_with_tags(b: &mut Bencher) {
     let client = new_queuing_nop_client();
     b.iter(|| {
-        let _ = client
+        client
             .count_with_tags("some.counter", 4)
             .with_tag("host", "web32.example.com")
             .with_tag("platform", "ng")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,6 +248,37 @@
 //! };
 //! ```
 //!
+//! ### Quiet Metric Sending and Error Handling
+//!
+//! When sending metrics sometimes you don't really care about the `Result` of
+//! trying to send it or maybe you just don't want to deal with it inline with
+//! the rest of your code. In order to handle this, Cadence allows you to set a
+//! default error handler. This handler is invoked when there are errors sending
+//! metrics so that the calling code doesn't have to deal with them.
+//!
+//! An example of configuring an error handler and an example of when it might
+//! be invoked is given below.
+//!
+//! ```rust,no_run
+//! use cadence::prelude::*;
+//! use cadence::{MetricError, StatsdClient, NopMetricSink};
+//!
+//! fn my_error_handler(err: MetricError) {
+//!     println!("Metric error! {}", err);
+//! }
+//!
+//! let client = StatsdClient::builder("prefix", NopMetricSink)
+//!     .with_error_handler(my_error_handler)
+//!     .build();
+//!
+//! // When sending metrics via the `MetricBuilder` used for assembling tags,
+//! // callers may opt into sending metrics quietly via the `.send()` method
+//! // as opposed to the `.try_send()` method
+//! client.count_with_tags("some.counter", 42)
+//!     .with_tag("region", "us-east-2")
+//!     .send();
+//! ```
+//!
 //! ### Custom Metric Sinks
 //!
 //! The Cadence `StatsdClient` uses implementations of the `MetricSink`
@@ -314,7 +345,8 @@ pub const DEFAULT_PORT: u16 = 8125;
 
 pub use self::builder::MetricBuilder;
 
-pub use self::client::{Counted, Gauged, Histogrammed, Metered, MetricClient, StatsdClient, Timed};
+pub use self::client::{Counted, Gauged, Histogrammed, Metered, MetricClient, StatsdClient,
+                       StatsdClientBuilder, Timed};
 
 pub use self::sinks::{BufferedUdpMetricSink, MetricSink, NopMetricSink, QueuingMetricSink,
                       UdpMetricSink};


### PR DESCRIPTION
Change the behavior of the `MetricBuilder::send()` method to not return
a result based on the sending of the metric. Users that want the result
can now use the `MetricBuilder::try_send()` method for sending
metrics.

On success, the output from sending the metric with `.send()` is
discarded. On error, a user supplied error handler is invoked to consume
the error. By default, if no handler is supplied, the errors are
silently discarded.

The motivation for discarding errors has a few parts:
* We don't want to add another dependency to Cadence.
* There have been issues opened in the past to remove logging from
  Cadence.
* Users that want to do something more elaborate will have a better
  idea of the right course of action than us.

Fixes #65 

/cc @pjenvey @robinst 