### PR TITLE
Proposal for Datadog extensions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,15 @@ keywords = ["statsd", "metrics"]
 [dependencies]
 crossbeam = "0.2.10"
 
+[dev-dependencies]
+regex = "0.2"
+
 [lib]
 name = "cadence"
 path = "src/lib.rs"
 
 [badges]
 travis-ci = { repository = "tshlabs/cadence" }
+
+[features]
+datadog-extensions = []

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -40,6 +40,10 @@ enum MetricType {
     Gauge,
     Meter,
     Histogram,
+    #[cfg(feature = "datadog-extensions")]
+    Set,
+    #[cfg(feature = "datadog-extensions")]
+    Distribution
 }
 
 impl fmt::Display for MetricType {
@@ -50,6 +54,10 @@ impl fmt::Display for MetricType {
             MetricType::Gauge => "g".fmt(f),
             MetricType::Meter => "m".fmt(f),
             MetricType::Histogram => "h".fmt(f),
+            #[cfg(feature = "datadog-extensions")]
+            MetricType::Set => "s".fmt(f),
+            #[cfg(feature = "datadog-extensions")]
+            MetricType::Distribution => "d".fmt(f),
         }
     }
 }
@@ -89,6 +97,16 @@ where
 
     pub(crate) fn histogram(prefix: &'a str, key: &'a str, val: u64) -> Self {
         Self::from_u64(prefix, key, val, MetricType::Histogram)
+    }
+
+    #[cfg(feature = "datadog-extensions")]
+    pub(crate) fn set(prefix: &'a str, key: &'a str, val: i64) -> Self {
+        Self::from_i64(prefix, key, val, MetricType::Set)
+    }
+
+    #[cfg(feature = "datadog-extensions")]
+    pub(crate) fn distribution(prefix: &'a str, key: &'a str, val: i64) -> Self {
+        Self::from_i64(prefix, key, val, MetricType::Distribution)
     }
 
     fn from_u64(prefix: &'a str, key: &'a str, val: u64, type_: MetricType) -> Self {
@@ -376,7 +394,7 @@ where
     }
 }
 
-fn datadog_tags_size_hint(tags: &[(Option<&str>, &str)]) -> usize {
+pub(crate) fn datadog_tags_size_hint(tags: &[(Option<&str>, &str)]) -> usize {
     // enough space for prefix, tags/: separators and commas
     let kv_size: usize = tags.iter()
         .map(|tag| {
@@ -387,7 +405,7 @@ fn datadog_tags_size_hint(tags: &[(Option<&str>, &str)]) -> usize {
     DATADOG_TAGS_PREFIX.len() + kv_size + tags.len() - 1
 }
 
-fn write_datadog_tags(metric: &mut String, tags: &[(Option<&str>, &str)]) {
+pub(crate) fn write_datadog_tags(metric: &mut String, tags: &[(Option<&str>, &str)]) {
     metric.push_str(DATADOG_TAGS_PREFIX);
     for (i, &(key, value)) in tags.iter().enumerate() {
         if i > 0 {

--- a/src/client.rs
+++ b/src/client.rs
@@ -195,7 +195,6 @@ pub trait Histogrammed {
 /// ```
 pub trait MetricClient: Counted + Timed + Gauged + Metered + Histogrammed {}
 
-
 /// Builder for creating and customizing `StatsdClient` instances.
 ///
 /// Instances of the builder should be created by calling the `::builder()`
@@ -388,7 +387,7 @@ impl StatsdClientBuilder {
 /// an `Arc`.
 #[derive(Clone)]
 pub struct StatsdClient {
-    prefix: String,
+    pub(crate) prefix: String,
     sink: Arc<MetricSink + Sync + Send>,
     errors: Arc<Fn(MetricError) -> () + Sync + Send>,
 }

--- a/src/datadog/builder.rs
+++ b/src/datadog/builder.rs
@@ -1,0 +1,831 @@
+use std::fmt::{self, Write};
+use std::marker::PhantomData;
+use std::default::Default;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use types::{Metric, MetricError, MetricResult};
+use builder::{datadog_tags_size_hint, write_datadog_tags};
+use client::StatsdClient;
+use super::types::{MAX_EVENT_LENGTH, max_event_exceeded_error};
+
+// A UNIX timpestamp for the event
+#[derive(PartialEq, Eq, Debug, Hash, Clone)]
+struct EventTimestamp(u64);
+
+impl fmt::Display for EventTimestamp {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Default for EventTimestamp {
+    fn default() -> Self {
+        EventTimestamp::now()
+    }
+}
+
+impl EventTimestamp {
+    fn now() -> Self {
+        let since_epoch = SystemTime::now().duration_since(UNIX_EPOCH).expect("Time went backwards");
+
+        EventTimestamp(since_epoch.as_secs())
+    }
+
+    fn from_secs(secs: u64) -> Self {
+        EventTimestamp(secs)
+    }
+}
+
+/// The priority of an event. Needed to use
+/// [EventBuilder::with_priority](struct.EventBuilder.html#method.with_priority).
+///
+/// See [Datadog](https://docs.datadoghq.com/developers/dogstatsd/).
+#[derive(PartialEq, Eq, Debug, Hash, Clone)]
+pub enum EventPriority {
+    Low,
+    Normal
+}
+
+impl fmt::Display for EventPriority {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            EventPriority::Low => "low".fmt(f),
+            EventPriority::Normal => "normal".fmt(f)
+        }
+    }
+}
+
+impl Default for EventPriority {
+    fn default() -> Self {
+        EventPriority::Normal
+    }
+}
+
+/// The the source type name of an event. Needed to use
+///
+/// See [Datadog](https://docs.datadoghq.com/developers/dogstatsd/).
+#[derive(PartialEq, Eq, Debug, Hash, Clone)]
+struct EventSourceTypeName<'a>(&'a str);
+
+impl<'a> fmt::Display for EventSourceTypeName<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// The alert type of an event. Needed to use
+/// [EventBuilder::with_priority](struct.EventBuilder.html#method.with_alert_type).
+///
+/// See [Datadog](https://docs.datadoghq.com/developers/dogstatsd/).
+#[derive(PartialEq, Eq, Debug, Hash, Clone)]
+pub enum EventAlertType {
+    Info,
+    Error,
+    Warning,
+    Success
+}
+
+impl Default for EventAlertType {
+    fn default() -> Self {
+        EventAlertType::Info
+    }
+}
+
+impl fmt::Display for EventAlertType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            EventAlertType::Info => "info".fmt(f),
+            EventAlertType::Error => "error".fmt(f),
+            EventAlertType::Warning => "warning".fmt(f),
+            EventAlertType::Success => "success".fmt(f)
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Debug, Hash, Clone)]
+pub(crate) struct EventFormatter<'a, T>
+where
+    T: Metric + From<String>,
+{
+    event: PhantomData<T>,
+    prefix: &'a str,
+    title: &'a str,
+    text: &'a str,
+    timestamp: EventTimestamp,
+    hostname: Option<&'a str>,
+    aggregation_key: Option<&'a str>,
+    priority: EventPriority,
+    src_type: Option<&'a str>,
+    alert_type: EventAlertType,
+    tags: Option<Vec<(Option<&'a str>, &'a str)>>,
+    title_len: usize,
+    text_len: usize,
+}
+
+impl<'a, T> EventFormatter<'a, T>
+where
+    T: Metric + From<String>,
+{
+    pub(crate) fn new(prefix: &'a str, title: &'a str, text:  &'a str) -> Self {
+        let prefix_len = prefix.chars().count();
+        let title_len = title.chars().count();
+        let text_len = text.chars().count();
+
+        EventFormatter {
+            event: PhantomData,
+            prefix: prefix,
+            title: title,
+            text: text,
+            timestamp: Default::default(),
+            hostname: None,
+            aggregation_key: None,
+            priority: Default::default(),
+            src_type: None,
+            alert_type: Default::default(),
+            tags: None,
+            title_len: title_len + prefix_len + 1, // 1 for '.'
+            text_len: text_len,
+        }
+    }
+
+    pub(crate) fn event(prefix: &'a str, title: &'a str, text:  &'a str) -> Self {
+        Self::new(prefix, title, text)
+    }
+
+    fn with_timestamp(&mut self, timestamp: u64) {
+        self.timestamp = EventTimestamp::from_secs(timestamp)
+    }
+
+    fn with_hostname(&mut self, hostname: &'a str) {
+        self.hostname = Some(hostname)
+    }
+
+    fn with_aggregation_key(&mut self, key: &'a str) {
+        self.aggregation_key = Some(key)
+    }
+
+    fn with_priority(&mut self, priority: EventPriority) {
+        self.priority = priority
+    }
+
+    fn with_src_type_name(&mut self, src_type: &'a str) {
+        self.src_type = Some(src_type)
+    }
+
+    fn with_alert_type(&mut self, alert_type: EventAlertType) {
+        self.alert_type = alert_type
+    }
+
+    fn with_tag(&mut self, key: &'a str, value: &'a str) {
+        self.tags
+            .get_or_insert_with(Vec::new)
+            .push((Some(key), value));
+    }
+
+    fn with_tag_value(&mut self, value: &'a str) {
+        self.tags.get_or_insert_with(Vec::new).push((None, value));
+    }
+
+    fn write_base_metric(&self, out: &mut String) {
+        let _ = write!(
+            out,
+            "_e{{{},{}}}:{}.{}|{}|d:{}|p:{}|t:{}",
+            self.title_len,
+            self.text_len,
+            self.prefix,
+            self.title,
+            self.text,
+            self.timestamp,
+            self.priority,
+            self.alert_type
+        );
+
+        if let Some(hostname) =  self.hostname.as_ref() {
+            let _ = write!(out, "|h:{}", hostname);
+        }
+
+        if let Some(aggregation_key) =  self.aggregation_key.as_ref() {
+            let _ = write!(out, "|k:{}", aggregation_key);
+        }
+
+        if let Some(src_type_name) =  self.src_type.as_ref() {
+            let _ = write!(out, "|s:{}", src_type_name);
+        }
+    }
+
+    fn write_tags(&self, out: &mut String) {
+        if let Some(tags) = self.tags.as_ref() {
+            write_datadog_tags(out, tags);
+        }
+    }
+
+    // FIXME: This might be actually more expensive than resizing the string
+    fn size_hint(&self) -> usize {
+        let mut size = 2 +          // _e
+            1 +                     // {
+            4 +                     // title length 4 because of the max size len
+            4 +                     // text length 4 because of the max size len
+            2 +                     // }:
+            self.prefix.len() + 1 + self.title.len() + 1 + // prefix + '.' + title + '|'
+            self.text.len() + 1 +   // text_len and '|'
+            13 +                    // 'd:' + bytes for the timestamp and '|'
+            9 +                     // 'p:' bytes for max priority and '|'
+            8;                      // 't:' bytes for max alert type and '|'
+
+        if let Some(hostname) =  self.hostname.as_ref() {
+            size += hostname.len() + 1 // hostname length + '|'
+        }
+
+        if let Some(aggregation_key) =  self.aggregation_key.as_ref() {
+            size += aggregation_key.len() + 1 // aggregation_key + '|'
+        }
+
+        if let Some(src_type_name) =  self.src_type.as_ref() {
+            size += src_type_name.len() + 1  // source type name + '|'
+        }
+
+        if let Some(tags) = self.tags.as_ref() {
+            size + datadog_tags_size_hint(tags)
+        } else {
+            size
+        }
+    }
+
+    pub(crate) fn build(&self) -> MetricResult<T> {
+        let mut metric_string = String::with_capacity(self.size_hint());
+        self.write_base_metric(&mut metric_string);
+        self.write_tags(&mut metric_string);
+
+        if metric_string.len() > MAX_EVENT_LENGTH {
+            Err(max_event_exceeded_error())
+        } else {
+            Ok(T::from(metric_string))
+        }
+    }
+}
+
+/// Internal state of a `EventBuilder`
+///
+/// The builder can either be in the process of formatting a metric to send
+/// via a client or it can be simply holding on to an error that it will return
+/// to a caller when `.send()` is finally invoked.
+#[derive(Debug)]
+enum BuilderRepr<'m, 'c, T>
+where
+    T: Metric + From<String>,
+{
+    Success(EventFormatter<'m, T>, &'c StatsdClient),
+    Error(MetricError, &'c StatsdClient),
+}
+
+/// Builder for customizing and adding tags to in-progress events.
+///
+/// This builder adds tags, key-value pairs or just values, as well as
+/// custom values for the optional fields of an event previously constructed
+/// by a call to `StatsdClient::custom_event`. The tags and customized 
+/// values are added to events and sent via the client when
+/// `EventBuilder::send()` is invoked. Any errors countered constructing,
+/// validating, or sending the metrics will be propagated and returned when
+/// the `.send()` method is finally invoked.
+///
+/// Datadog style tags are supported. For more information on the
+/// exact format used, see the
+/// [Datadog docs](https://docs.datadoghq.com/developers/dogstatsd/#datagram-format).
+///
+/// Adding tags to a metric via this builder will typically result in one or more
+/// extra heap allocations.
+///
+/// Regarding the customizable values for the event fields you can send custom:
+///
+/// - Timestamp via `EventBuilder::with_timestamp()`.
+/// - Hostname via `EventBuilder::with_hostname()`.
+/// - Aggregation via `EventBuilder::with_aggregation_key()`.
+/// - Priority via `EventBuilder::with_priority()` See `EventPriority` for possible
+/// values.
+/// - Source Type Name via `EventBuilder::with_src_type()`.
+/// - Alert type `EventBuilder::with_alert_type()` See `EventAlertType` for possible
+/// values.
+///
+/// Note that events are a [Datadog](https://docs.datadoghq.com/developers/dogstatsd/)
+/// extension to Statsd and may not be supported by your server.
+///
+/// NOTE: The only way to instantiate an instance of this builder is via methods in
+/// in the `StatsdClient` client.
+///
+/// # Example
+///
+/// An example of how the event builder is used with a `StatsdClient` instance
+/// is given below.
+///
+/// ```
+/// use cadence::prelude::*;
+/// use cadence::{StatsdClient, NopMetricSink, Metric, EventPriority, EventAlertType};
+///
+/// let client = StatsdClient::from_sink("myapp", NopMetricSink);
+/// let res = client.custom_event("exception", "something bad!")
+///     .with_timestamp(1523292353)
+///     .with_hostname("example.com")
+///     .with_aggregation_key("aggreg_key")
+///     .with_priority(EventPriority::Low)
+///     .with_src_type("src_type")
+///     .with_alert_type(EventAlertType::Error)
+///     .try_send();
+///
+///     assert_eq!(
+///         "_e{15,14}:myapp.exception|something bad!|d:1523292353|p:low|t:error|h:example.com|k:aggreg_key|s:src_type",
+///         res.unwrap().as_metric_str()
+///     );
+/// ```
+/// In this example, two key-value tags and one value tag are added to the
+/// metric before it is finally sent to the Statsd server.
+#[must_use = "Did you forget to call .send() after customizing the event?"]
+#[derive(Debug)]
+pub struct EventBuilder<'m, 'c, T>
+where
+    T: Metric + From<String>,
+{
+    repr: BuilderRepr<'m, 'c, T>,
+}
+
+impl<'m, 'c, T> EventBuilder<'m, 'c, T>
+where
+    T: Metric + From<String>,
+{
+    pub(crate) fn new(formatter: EventFormatter<'m, T>, client: &'c StatsdClient) -> Self {
+        EventBuilder {
+            repr: BuilderRepr::Success(formatter, client),
+        }
+    }
+
+    pub(crate) fn from_error(err: MetricError, client: &'c StatsdClient) -> Self {
+        EventBuilder {
+            repr: BuilderRepr::Error(err, client),
+        }
+    }
+
+    /// Add a key-value tag to this metric.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cadence::prelude::*;
+    /// use cadence::{StatsdClient, NopMetricSink, Metric};
+    ///
+    /// let client = StatsdClient::from_sink("my.app", NopMetricSink);
+    /// let res = client.incr_with_tags("some.key")
+    ///    .with_tag("user", "authenticated")
+    ///    .try_send();
+    ///
+    /// assert_eq!(
+    ///    "my.app.some.key:1|c|#user:authenticated",
+    ///    res.unwrap().as_metric_str()
+    /// );
+    /// ```
+    pub fn with_tag(mut self, key: &'m str, value: &'m str) -> Self {
+        if let BuilderRepr::Success(ref mut formatter, _) = self.repr {
+            formatter.with_tag(key, value);
+        }
+
+        self
+    }
+
+    /// Add a value tag to this metric.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cadence::prelude::*;
+    /// use cadence::{StatsdClient, NopMetricSink, Metric};
+    ///
+    /// let client = StatsdClient::from_sink("my.app", NopMetricSink);
+    /// let res = client.count_with_tags("some.key", 4)
+    ///    .with_tag_value("beta-testing")
+    ///    .try_send();
+    ///
+    /// assert_eq!(
+    ///    "my.app.some.key:4|c|#beta-testing",
+    ///    res.unwrap().as_metric_str()
+    /// );
+    /// ```
+    pub fn with_tag_value(mut self, value: &'m str) -> Self {
+        if let BuilderRepr::Success(ref mut formatter, _) = self.repr {
+            formatter.with_tag_value(value);
+        }
+
+        self
+    }
+
+    /// Customize the timestamp of the event.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cadence::prelude::*;
+    /// use cadence::{StatsdClient, NopMetricSink, Metric};
+    ///
+    /// let client = StatsdClient::from_sink("my.app", NopMetricSink);
+    /// let res = client
+    ///     .custom_event("exception", "something bad happened")
+    ///     .with_timestamp(1523292353)
+    ///     .try_send();
+    /// ```
+    pub fn with_timestamp(mut self, timestamp: u64) -> Self {
+        if let BuilderRepr::Success(ref mut formatter, _) = self.repr {
+            formatter.with_timestamp(timestamp);
+        }
+
+        self
+    }
+
+    /// Add a hostname to the event.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cadence::prelude::*;
+    /// use cadence::{StatsdClient, NopMetricSink, Metric};
+    ///
+    /// let client = StatsdClient::from_sink("my.app", NopMetricSink);
+    /// let res = client
+    ///     .custom_event("exception", "something bad happened")
+    ///     .with_hostname("example.com")
+    ///     .try_send();
+    /// ```
+    pub fn with_hostname(mut self, hostname: &'m str) -> Self {
+        if let BuilderRepr::Success(ref mut formatter, _) = self.repr {
+            formatter.with_hostname(hostname);
+        }
+
+        self
+    }
+
+    /// Add an aggregation key to the event.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cadence::prelude::*;
+    /// use cadence::{StatsdClient, NopMetricSink};
+    ///
+    /// let client = StatsdClient::from_sink("my.app", NopMetricSink);
+    /// let res = client
+    ///     .custom_event("exception", "something bad happened")
+    ///     .with_aggregation_key("aggregate_me")
+    ///     .send();
+    /// ```
+    pub fn with_aggregation_key(mut self, key: &'m str) -> Self {
+        if let BuilderRepr::Success(ref mut formatter, _) = self.repr {
+            formatter.with_aggregation_key(key);
+        }
+
+        self
+    }
+
+   /// Customize the priority of the event.
+   ///
+   /// # Example
+   ///
+   /// ```
+   /// use cadence::prelude::*;
+   /// use cadence::{StatsdClient, NopMetricSink, EventPriority};
+   ///
+   /// let client = StatsdClient::from_sink("my.app", NopMetricSink);
+   /// let res = client
+   ///     .custom_event("exception", "something bad happened")
+   ///     .with_priority(EventPriority::Low)
+   ///     .send();
+   /// ```
+   pub fn with_priority(mut self, priority: EventPriority) -> Self {
+        if let BuilderRepr::Success(ref mut formatter, _) = self.repr {
+            formatter.with_priority(priority);
+        }
+
+        self
+    }
+
+    /// Add a source type name to the event.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cadence::prelude::*;
+    /// use cadence::{StatsdClient, NopMetricSink};
+    ///
+    /// let client = StatsdClient::from_sink("my.app", NopMetricSink);
+    /// let res = client
+    ///     .custom_event("exception", "something bad happened")
+    ///     .with_src_type("my_src_type_name")
+    ///     .send();
+    /// ```
+    pub fn with_src_type(mut self, src_type_name: &'m str) -> Self {
+        if let BuilderRepr::Success(ref mut formatter, _) = self.repr {
+            formatter.with_src_type_name(src_type_name);
+        }
+
+        self
+    }
+
+    /// Customize the alert type of the event.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cadence::prelude::*;
+    /// use cadence::{StatsdClient, NopMetricSink, EventAlertType};
+    ///
+    /// let client = StatsdClient::from_sink("my.app", NopMetricSink);
+    /// let res = client
+    ///     .custom_event("exception", "I am not ok with the events currently unfolding")
+    ///     .with_alert_type(EventAlertType::Warning)
+    ///     .send();
+    /// ```
+    pub fn with_alert_type(mut self, alert_type: EventAlertType) -> Self {
+        if let BuilderRepr::Success(ref mut formatter, _) = self.repr {
+            formatter.with_alert_type(alert_type);
+        }
+
+        self
+    }
+
+    /// Send a metric using the client that created this builder.
+    ///
+    /// Note that the builder is consumed by this method and thus `.try_send()`
+    /// can only be called a single time per builder.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cadence::prelude::*;
+    /// use cadence::{StatsdClient, NopMetricSink, Metric};
+    ///
+    /// let client = StatsdClient::from_sink("some.prefix", NopMetricSink);
+    /// let res = client.gauge_with_tags("some.key", 7)
+    ///    .with_tag("test-segment", "12345")
+    ///    .try_send();
+    ///
+    /// assert_eq!(
+    ///    "some.prefix.some.key:7|g|#test-segment:12345",
+    ///    res.unwrap().as_metric_str()
+    /// );
+    /// ```
+    pub fn try_send(self) -> MetricResult<T> {
+        match self.repr {
+            BuilderRepr::Error(err, _) => Err(err),
+            BuilderRepr::Success(ref formatter, client) => {
+                let metric: T = formatter.build()?;
+                client.send_metric(&metric)?;
+                Ok(metric)
+            }
+        }
+    }
+
+    /// Send an event using the client that created this builder.
+    ///
+    /// Note that the builder is consumed by this method and thus `.send()` can
+    /// only be called a single time per builder.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cadence::prelude::*;
+    /// use cadence::{StatsdClient, NopMetricSink, Metric};
+    ///
+    /// let client = StatsdClient::from_sink("my.app", NopMetricSink);
+    /// client.gauge_with_tags("some.key", 7)
+    ///    .with_tag("test-segment", "12345")
+    ///    .send();
+    /// ```
+    pub fn send(self) -> () {
+        match self.repr {
+            BuilderRepr::Error(err, client) => client.consume_error(err),
+            BuilderRepr::Success(_, client) => {
+                if let Err(e) = self.try_send() {
+                    client.consume_error(e);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::Event;
+    // So, basically with these `size_hint` tests I'm trying to assert that at most we will do only
+    // one allocation when creating the metric and that the amount of bytes allocated does not exceed
+    // 16% from the real amount of bytes needed to store the metric string.
+    // 16% Seems arbitrary but that was what I calculated from the curent `size_hint` implementation
+    // without making it too expensive to call which would make it pointless.
+    const SIZE_HINT_MAX_PERCENT: f32 = 0.16; // 16 %
+
+    #[test]
+    fn test_size_hint_default() {
+        let ef: EventFormatter<Event> = EventFormatter::new("my.app", "exception", "boom!");
+
+        let event: Event = ef.build().unwrap();
+
+        let max_expected_gap = (event.as_metric_str().len() as f32 * SIZE_HINT_MAX_PERCENT) as usize;
+        let size_hint_gap = ef.size_hint() - event.as_metric_str().len();
+        assert!(size_hint_gap <= max_expected_gap);
+    }
+
+    #[test]
+    fn test_size_hint_with_timestamp() {
+        let mut ef: EventFormatter<Event> = EventFormatter::new("my.app", "exception", "boom!");
+        // So by the time we really need a <u64>::max_value() we will not be around here
+        // however the timestamp is u64 because of the Year 2038 problem.
+        ef.with_timestamp(<u32>::max_value() as u64);
+
+        let event: Event = ef.build().unwrap();
+
+        let max_expected_gap = (event.as_metric_str().len() as f32 * SIZE_HINT_MAX_PERCENT) as usize;
+        let size_hint_gap = ef.size_hint() - event.as_metric_str().len();
+        assert!(size_hint_gap <= max_expected_gap);
+    }
+
+    #[test]
+    fn test_size_hint_with_hostname() {
+        let mut ef: EventFormatter<Event> = EventFormatter::new("my.app", "exception", "boom!");
+        ef.with_hostname("example.com");
+
+        let event: Event = ef.build().unwrap();
+
+        let max_expected_gap = (event.as_metric_str().len() as f32 * SIZE_HINT_MAX_PERCENT) as usize;
+        let size_hint_gap = ef.size_hint() - event.as_metric_str().len();
+        assert!(size_hint_gap <= max_expected_gap);
+    }
+
+    #[test]
+    fn test_size_hint_with_aggregation_key() {
+        let mut ef: EventFormatter<Event> = EventFormatter::new("my.app", "exception", "boom!");
+        ef.with_aggregation_key("foo");
+
+        let event: Event = ef.build().unwrap();
+
+        let max_expected_gap = (event.as_metric_str().len() as f32 * SIZE_HINT_MAX_PERCENT) as usize;
+        let size_hint_gap = ef.size_hint() - event.as_metric_str().len();
+        assert!(size_hint_gap <= max_expected_gap);
+    }
+
+    #[test]
+    fn test_size_hint_with_priority() {
+        let mut ef: EventFormatter<Event> = EventFormatter::new("my.app", "exception", "boom!");
+        ef.with_priority(EventPriority::Low);
+
+        let event: Event = ef.build().unwrap();
+
+        let max_expected_gap = (event.as_metric_str().len() as f32 * SIZE_HINT_MAX_PERCENT) as usize;
+        let size_hint_gap = ef.size_hint() - event.as_metric_str().len();
+        assert!(size_hint_gap <= max_expected_gap);
+    }
+
+    #[test]
+    fn test_size_hint_with_normal() {
+        let mut ef: EventFormatter<Event> = EventFormatter::new("my.app", "exception", "boom!");
+        ef.with_priority(EventPriority::Normal);
+
+        let event: Event = ef.build().unwrap();
+
+        let max_expected_gap = (event.as_metric_str().len() as f32 * SIZE_HINT_MAX_PERCENT) as usize;
+        let size_hint_gap = ef.size_hint() - event.as_metric_str().len();
+        assert!(size_hint_gap <= max_expected_gap);
+    }
+
+    #[test]
+    fn test_size_hint_with_src_type_name() {
+        let mut ef: EventFormatter<Event> = EventFormatter::new("my.app", "exception", "boom!");
+        ef.with_src_type_name("bar");
+
+        let event: Event = ef.build().unwrap();
+
+        let max_expected_gap = (event.as_metric_str().len() as f32 * SIZE_HINT_MAX_PERCENT) as usize;
+        let size_hint_gap = ef.size_hint() - event.as_metric_str().len();
+        assert!(size_hint_gap <= max_expected_gap);
+    }
+
+    #[test]
+    fn test_size_hint_with_alert_type() {
+        let mut ef: EventFormatter<Event> = EventFormatter::new("my.app", "exception", "boom!");
+        ef.with_alert_type(EventAlertType::Error);
+
+        let event: Event = ef.build().unwrap();
+
+        let max_expected_gap = (event.as_metric_str().len() as f32 * SIZE_HINT_MAX_PERCENT) as usize;
+        let size_hint_gap = ef.size_hint() - event.as_metric_str().len();
+        assert!(size_hint_gap <= max_expected_gap);
+    }
+
+    #[test]
+    fn test_size_hint_with_alert_type_error() {
+        let mut ef: EventFormatter<Event> = EventFormatter::new("my.app", "exception", "boom!");
+        ef.with_alert_type(EventAlertType::Error);
+
+        let event: Event = ef.build().unwrap();
+
+        let max_expected_gap = (event.as_metric_str().len() as f32 * SIZE_HINT_MAX_PERCENT) as usize;
+        let size_hint_gap = ef.size_hint() - event.as_metric_str().len();
+        assert!(size_hint_gap <= max_expected_gap);
+    }
+
+    #[test]
+    fn test_size_hint_with_alert_type_warning() {
+        let mut ef: EventFormatter<Event> = EventFormatter::new("my.app", "exception", "boom!");
+        ef.with_alert_type(EventAlertType::Warning);
+
+        let event: Event = ef.build().unwrap();
+
+        let max_expected_gap = (event.as_metric_str().len() as f32 * SIZE_HINT_MAX_PERCENT) as usize;
+        let size_hint_gap = ef.size_hint() - event.as_metric_str().len();
+        assert!(size_hint_gap <= max_expected_gap);
+    }
+
+    #[test]
+    fn test_size_hint_with_alert_info() {
+        let mut ef: EventFormatter<Event> = EventFormatter::new("my.app", "exception", "boom!");
+        ef.with_alert_type(EventAlertType::Info);
+
+        let event: Event = ef.build().unwrap();
+
+        let max_expected_gap = (event.as_metric_str().len() as f32 * SIZE_HINT_MAX_PERCENT) as usize;
+        let size_hint_gap = ef.size_hint() - event.as_metric_str().len();
+        assert!(size_hint_gap <= max_expected_gap);
+    }
+
+    #[test]
+    fn test_size_hint_with_alert_success() {
+        let mut ef: EventFormatter<Event> = EventFormatter::new("my.app", "exception", "boom!");
+        ef.with_alert_type(EventAlertType::Success);
+
+        let event: Event = ef.build().unwrap();
+
+        let max_expected_gap = (event.as_metric_str().len() as f32 * SIZE_HINT_MAX_PERCENT) as usize;
+        let size_hint_gap = ef.size_hint() - event.as_metric_str().len();
+        assert!(size_hint_gap <= max_expected_gap);
+    }
+
+    #[test]
+    fn test_size_hint_with_all_long_text() {
+        let really_long_text = r#"
+            with an Apple Macintosh
+            you can't run Radio Shack programs
+            in its disc drive.
+
+            nor can a Commodore 64
+            drive read a file
+            you have created on an
+            IBM Personal Computer.
+
+            both Kaypro and Osborne computers use
+            the CP/M operating system
+            but can't read each other's
+            handwriting
+            for they format (write
+            on) discs in different
+            ways.
+
+            the Tandy 2000 runs MS-DOS but
+            can't use most programs produced for
+            the IBM Personal Computer
+            unless certain
+            bits and bytes are
+            altered
+            but the wind still blows over
+            Savannah
+            and in the Spring
+            the turkey buzzard struts and
+            flounces before his
+            hens.
+        "#;
+
+        let mut ef: EventFormatter<Event> = EventFormatter::new("my.app", "exception", really_long_text);
+        ef.with_timestamp(2147483647);
+        ef.with_hostname("example.com");
+        ef.with_aggregation_key("aggreg_key");
+        ef.with_priority(EventPriority::Low);
+        ef.with_src_type_name("src_type");
+        ef.with_alert_type(EventAlertType::Error);
+
+        let event: Event = ef.build().unwrap();
+
+        let max_expected_gap = (event.as_metric_str().len() as f32 * SIZE_HINT_MAX_PERCENT) as usize;
+        let size_hint_gap = ef.size_hint() - event.as_metric_str().len();
+        assert!(size_hint_gap <= max_expected_gap);
+    }
+
+    #[test]
+    fn test_formatter_max_event_length_error() {
+        use types::ErrorKind;
+
+        let mut text = String::new();
+        let letters = &mut ['L', 'O', 'R'].into_iter().cycle();
+        for _ in 0..MAX_EVENT_LENGTH {
+            text.push(*letters.next().unwrap());
+        }
+
+        let ef: EventFormatter<Event> = EventFormatter::new("my.app", "exception", &text);
+        let res = ef.build();
+
+        assert!(res.is_err());
+        assert_eq!(ErrorKind::InvalidInput, res.unwrap_err().kind());
+    }
+}

--- a/src/datadog/client.rs
+++ b/src/datadog/client.rs
@@ -1,0 +1,551 @@
+use client::{MetricClient, StatsdClient};
+use types::MetricResult;
+use builder::{MetricBuilder, MetricFormatter};
+use datadog::types::{Event, Set, Distribution};
+use datadog::builder::{EventBuilder, EventFormatter};
+use super::types::{MAX_EVENT_LENGTH, max_event_exceeded_error};
+
+/// Trait for recording Datadog set values.
+///
+/// Sets count the number of unique elements in a group. You can use them to,
+/// for example, grouping the unique visitors to your site.
+///
+/// See the [Statsd spec](https://github.com/b/statsd_spec) for more
+/// information.
+///
+/// Note that sets are a
+/// [Datadog](https://docs.datadoghq.com/developers/dogstatsd/) extension to
+/// Statsd and may not be supported by your server.
+pub trait Setted {
+    /// Record a single set value with the given key
+    fn set(&self, key: &str, value: i64) -> MetricResult<Set>;
+
+    /// Record a single set value with the given key and return a
+    /// `MetricBuilder` that can be used to add tags to the metric.
+    fn set_with_tags<'a>(&'a self, key: &'a str, value: i64) -> MetricBuilder<Set>;
+}
+
+/// Trait for recording Datadog distribution values.
+///
+/// Distribution values are positive values that can represent anything, whose
+/// statistical distribution is calculated by the server. The values can be
+/// timings, amount of some resource consumed, size of HTTP responses in
+/// some application, etc. Histograms can be thought of as a more general
+/// form of timers.
+///
+/// See the [Statsd spec](https://github.com/b/statsd_spec) for more
+/// information.
+///
+/// Note: Distributions are a
+/// [Datadog](https://docs.datadoghq.com/developers/dogstatsd/) extension to
+/// Statsd and are currently a beta feature of Datadog and not generally
+/// available. Distributions must be specifically enabled for your
+/// organization.
+pub trait Distributed {
+    /// Record a value to be tracked as a distribution to the statsd server.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cadence::prelude::*;
+    /// use cadence::{StatsdClient, NopMetricSink};
+    ///
+    /// let client = StatsdClient::from_sink("myapp", NopMetricSink);
+    /// client.distribution("some.distribution", 5);
+    /// ```
+    fn distribution(&self, key: &str, value: i64) -> MetricResult<Distribution>;
+
+    /// Record a single distribution value with the given key and return a
+    /// `MetricBuilder` that can be used to add tags to the metric.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cadence::prelude::*;
+    /// use cadence::{StatsdClient, NopMetricSink};
+    ///
+    /// let client = StatsdClient::from_sink("myapp", NopMetricSink);
+    /// client.distribution_with_tags("some.distribution", 5)
+    ///     .with_tag("foo", "bar");
+    /// ```
+    fn distribution_with_tags<'a>(&'a self, key: &'a str, value: i64) -> MetricBuilder<Distribution>;
+}
+
+/// Trait for recording Datadog event values.
+///
+/// Events are values sent to the datadog event stream and can be queried via the
+/// Datadog interface. You can tag them, set priority and even aggregate them with
+/// other events.
+///
+/// They are composed by the following fields:
+///
+/// - Title — Event title (Required).
+/// - Text — Event text/details (Required).
+/// - Timestamp (Optional) — Add a timestamp to the event. Default is the current Unix
+/// epoch timestamp.
+/// - Hostname (Optional) - Add a hostname to the event. No default.
+/// - Aggregation Key (Optional) — Add an aggregation key to group the event with others that have
+/// the same key. No default.
+/// - Priority (Optional) — Set to ‘normal’ or ‘low’. Default ‘normal’.
+/// - Source Type Name (Optional) - Add a source type to the event. No default.
+/// - Alert Type (Optional) — Set to ‘error’, ‘warning’, ‘info’ or ‘success’. Default ‘info’.
+///
+/// Note that events are a
+/// [Datadog](https://docs.datadoghq.com/developers/dogstatsd/) extension to
+/// Statsd and may not be supported by your server.
+pub trait Evented {
+    /// Record a single event value with the given title and text
+    /// using the following defaults for the rest of the fields:
+    ///
+    /// - Timestamp: The current Unix epoch timestamp.
+    /// - Hostname: none.
+    /// - Aggregation Key: none.
+    /// - Priority: `EventPriority::Normal`.
+    /// - Source Type Name: none.
+    /// - Alert Type: `EventAlertType::Info`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cadence::prelude::*;
+    /// use cadence::{StatsdClient, NopMetricSink};
+    ///
+    /// let client = StatsdClient::from_sink("myapp", NopMetricSink);
+    /// client.event("exception", "something bad happened");
+    /// ```
+    fn event(&self, title: &str, text: &str) -> MetricResult<Event>;
+
+    /// Record a single event value with the given title and text
+    /// returning a `MetricBuilder` that can be used to add tags
+    /// and customize the event.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cadence::prelude::*;
+    /// use cadence::{StatsdClient, NopMetricSink, EventAlertType, EventPriority};
+    ///
+    /// let client = StatsdClient::from_sink("myapp", NopMetricSink);
+    /// client.custom_event("exception", "server in flames!")
+    ///     .with_timestamp(1523292353)
+    ///     .with_hostname("example.com")
+    ///     .with_aggregation_key("aggreg_key")
+    ///     .with_priority(EventPriority::Low)
+    ///     .with_src_type("src_type")
+    ///     .with_alert_type(EventAlertType::Error)
+    ///     .with_tag("foo", "bar")
+    ///     .with_tag_value("quux")
+    ///     .send();
+    ///
+    /// ```
+    fn custom_event<'a>(&'a self, title: &'a str, text: &'a str) -> EventBuilder<Event>;
+}
+
+/// Trait that encompasses all other traits for sending metrics along with
+/// Datadog extensions.
+///
+/// If you wish to use `StatsdClient` with a generic type or place a
+/// `StatsdClient` instance behind a pointer (such as a `Box`) this will allow
+/// you to reference all the implemented methods for recording metrics, while
+/// using a single trait. An example of this is shown below.
+///
+/// ```
+/// use cadence::{DatadogMetricClient, StatsdClient, NopMetricSink};
+///
+/// let client: Box<DatadogMetricClient> = Box::new(StatsdClient::from_sink(
+///     "myapp", NopMetricSink));
+///
+/// client.count("some.counter", 1).unwrap();
+/// client.time("some.timer", 42).unwrap();
+/// client.gauge("some.gauge", 8).unwrap();
+/// client.meter("some.meter", 13).unwrap();
+/// client.histogram("some.histogram", 4).unwrap();
+/// client.set("some.set", 5).unwrap();
+/// client.distribution("some.distribution", 34).unwrap();
+/// client.event("exception", "something bad happened").unwrap();
+/// ```
+pub trait DatadogMetricClient: MetricClient + Setted + Distributed + Evented {}
+
+impl Setted for StatsdClient {
+    fn set(&self, key: &str, value: i64) -> MetricResult<Set> {
+        self.set_with_tags(key, value).try_send()
+    }
+
+    fn set_with_tags<'a>(&'a self, key: &'a str, value: i64) -> MetricBuilder<Set> {
+        let fmt = MetricFormatter::set(&self.prefix, key, value);
+        MetricBuilder::new(fmt, self)
+    }
+}
+
+impl Distributed for StatsdClient {
+    fn distribution(&self, key: &str, value: i64) -> MetricResult<Distribution> {
+        self.distribution_with_tags(key, value).try_send()
+    }
+
+    fn distribution_with_tags<'a>(&'a self, key: &'a str, value: i64) -> MetricBuilder<Distribution> {
+        let fmt = MetricFormatter::distribution(&self.prefix, key, value);
+        MetricBuilder::new(fmt, self)
+    }
+}
+
+impl Evented for StatsdClient {
+    fn event(&self, title: &str, text: &str) -> MetricResult<Event> {
+        self.custom_event(title, text).try_send()
+    }
+
+    fn custom_event<'a>(&'a self, title: &'a str, text: &'a str) -> EventBuilder<Event> {
+        let fmt = EventFormatter::event(&self.prefix, title, text);
+
+        let event_length = self.prefix.len() + title.len() + text.len();
+        let builder: EventBuilder<Event> = if event_length > MAX_EVENT_LENGTH {
+            EventBuilder::from_error(max_event_exceeded_error(), self)
+        } else {
+            EventBuilder::new(fmt, self)
+        };
+
+        builder
+    }
+}
+
+impl DatadogMetricClient for StatsdClient {}
+
+#[cfg(test)]
+mod tests {
+    use super::{Distributed, Setted, Evented, DatadogMetricClient, StatsdClient};
+    use sinks::NopMetricSink;
+    use types::Metric;
+
+    /// Strips the timestamp which is by default dynamic and then uses regular assert_eq!
+    macro_rules! assert_eq_ignore_timestamp {
+        ($left:expr, $right:expr) => ({
+            use regex::Regex;
+            let re = Regex::new(r"\|d:\d+").unwrap();
+
+            match (&$left, &$right) {
+                (left_val, right_val) => {
+                    let left_wo_timestamp = re.replace_all(*left_val, "");
+                    let right_wo_timestamp = re.replace_all(*right_val, "");
+                    assert_eq!(*left_wo_timestamp, right_wo_timestamp);
+                }
+            }
+        });
+    }
+
+    #[test]
+    fn test_statsd_client_set_no_tags() {
+        let client = StatsdClient::from_sink("myapp", NopMetricSink);
+        let res = client.set("some.set", 3);
+
+        assert_eq!(
+            "myapp.some.set:3|s",
+            res.unwrap().as_metric_str()
+        );
+    }
+
+    #[test]
+    fn test_statsd_client_set_with_tags() {
+        let client = StatsdClient::from_sink("myapp", NopMetricSink);
+        let res = client
+            .set_with_tags("some.set", 3)
+            .with_tag("foo", "bar")
+            .try_send();
+
+        assert_eq!(
+            "myapp.some.set:3|s|#foo:bar",
+            res.unwrap().as_metric_str()
+        );
+    }
+
+    #[test]
+    fn test_statsd_client_distribution_no_tags() {
+        let client = StatsdClient::from_sink("myapp", NopMetricSink);
+        let res = client.distribution("some.distribution", 5);
+
+        assert_eq!(
+            "myapp.some.distribution:5|d",
+            res.unwrap().as_metric_str()
+        );
+    }
+
+    #[test]
+    fn test_statsd_client_distribution_with_tags() {
+        let client = StatsdClient::from_sink("myapp", NopMetricSink);
+        let res = client
+            .distribution_with_tags("some.distribution", 5)
+            .with_tag("foo", "bar")
+            .try_send();
+
+        assert_eq!(
+            "myapp.some.distribution:5|d|#foo:bar",
+            res.unwrap().as_metric_str()
+        );
+    }
+
+    #[test]
+    fn test_statsd_client_event_no_tags() {
+        let client = StatsdClient::from_sink("myapp", NopMetricSink);
+        let res = client.event("exception", "something bad happened");
+
+        assert_eq_ignore_timestamp!(
+            "_e{15,22}:myapp.exception|something bad happened|p:normal|t:info",
+            res.unwrap().as_metric_str()
+        );
+    }
+
+    #[test]
+    fn test_statsd_client_custom_event_no_tags() {
+        let client = StatsdClient::from_sink("myapp", NopMetricSink);
+        let res = client.custom_event("exception", "something bad happened")
+            .try_send();
+
+        assert_eq_ignore_timestamp!(
+            "_e{15,22}:myapp.exception|something bad happened|p:normal|t:info",
+            res.unwrap().as_metric_str()
+        );
+    }
+
+    #[test]
+    fn test_statsd_client_custom_event_with_tags() {
+        let client = StatsdClient::from_sink("myapp", NopMetricSink);
+        let res = client.custom_event("exception", "something bad happened")
+            .with_tag("foo", "bar")
+            .with_tag_value("baz")
+            .try_send();
+
+        assert_eq_ignore_timestamp!(
+            "_e{15,22}:myapp.exception|something bad happened|p:normal|t:info|#foo:bar,baz",
+            res.unwrap().as_metric_str()
+        );
+    }
+
+    #[test]
+    fn test_statsd_client_custom_event_with_timestamp() {
+        let client = StatsdClient::from_sink("myapp", NopMetricSink);
+        let res = client
+            .custom_event("exception", "something bad happened")
+            .with_timestamp(1523292353)
+            .try_send();
+
+        assert_eq_ignore_timestamp!(
+            "_e{15,22}:myapp.exception|something bad happened|p:normal|t:info",
+            res.unwrap().as_metric_str()
+         );
+    }
+
+    #[test]
+    fn test_statsd_client_custom_event_with_hostname() {
+        let client = StatsdClient::from_sink("myapp", NopMetricSink);
+        let res = client
+            .custom_event("exception", "something bad happened")
+            .with_hostname("example.com")
+            .try_send();
+
+        assert_eq_ignore_timestamp!(
+            "_e{15,22}:myapp.exception|something bad happened|p:normal|t:info|h:example.com",
+            res.unwrap().as_metric_str()
+        );
+    }
+
+    #[test]
+    fn test_statsd_client_custom_event_aggregation_key() {
+        let client = StatsdClient::from_sink("myapp", NopMetricSink);
+        let res = client
+            .custom_event("exception", "something bad happened")
+            .with_aggregation_key("aggreg_key")
+            .try_send();
+
+        assert_eq_ignore_timestamp!(
+            "_e{15,22}:myapp.exception|something bad happened|p:normal|t:info|k:aggreg_key",
+            res.unwrap().as_metric_str()
+        );
+    }
+
+    #[test]
+    fn test_statsd_client_custom_event_with_priority_low() {
+        use datadog::builder::EventPriority;
+        let client = StatsdClient::from_sink("myapp", NopMetricSink);
+        let res = client
+            .custom_event("exception", "something bad happened")
+            .with_priority(EventPriority::Low)
+            .try_send();
+
+        assert_eq_ignore_timestamp!(
+            "_e{15,22}:myapp.exception|something bad happened|p:low|t:info",
+            res.unwrap().as_metric_str()
+        );
+    }
+
+    #[test]
+    fn test_statsd_client_custom_event_with_priority_normal() {
+        use datadog::builder::EventPriority;
+        let client = StatsdClient::from_sink("myapp", NopMetricSink);
+        let res = client
+            .custom_event("exception", "something bad happened")
+            .with_priority(EventPriority::Normal)
+            .try_send();
+
+        assert_eq_ignore_timestamp!(
+            "_e{15,22}:myapp.exception|something bad happened|p:normal|t:info",
+            res.unwrap().as_metric_str()
+        );
+    }
+
+    #[test]
+    fn test_statsd_client_custom_event_with_with_src_type_name() {
+        let client = StatsdClient::from_sink("myapp", NopMetricSink);
+        let res = client
+            .custom_event("exception", "something bad happened")
+            .with_src_type("src_type")
+            .try_send();
+
+        assert_eq_ignore_timestamp!(
+            "_e{15,22}:myapp.exception|something bad happened|p:normal|t:info|s:src_type",
+            res.unwrap().as_metric_str()
+        );
+    }
+
+    #[test]
+    fn test_statsd_client_custom_event_with_alert_typei_info() {
+        use datadog::builder::EventAlertType;
+
+        let client = StatsdClient::from_sink("myapp", NopMetricSink);
+        let res = client
+            .custom_event("exception", "something bad happened")
+            .with_alert_type(EventAlertType::Info)
+            .try_send();
+
+        assert_eq_ignore_timestamp!(
+            "_e{15,22}:myapp.exception|something bad happened|p:normal|t:info",
+            res.unwrap().as_metric_str()
+        );
+    }
+
+    #[test]
+    fn test_statsd_client_custom_event_with_alert_type_error() {
+        use datadog::builder::EventAlertType;
+
+        let client = StatsdClient::from_sink("myapp", NopMetricSink);
+        let res = client
+            .custom_event("exception", "something bad happened")
+            .with_alert_type(EventAlertType::Error)
+            .try_send();
+
+        assert_eq_ignore_timestamp!(
+            "_e{15,22}:myapp.exception|something bad happened|p:normal|t:error",
+            res.unwrap().as_metric_str()
+        );
+    }
+
+    #[test]
+    fn test_statsd_client_custom_event_with_alert_type_warning() {
+        use datadog::builder::EventAlertType;
+
+        let client = StatsdClient::from_sink("myapp", NopMetricSink);
+        let res = client
+            .custom_event("exception", "something bad happened")
+            .with_alert_type(EventAlertType::Warning)
+            .try_send();
+
+        assert_eq_ignore_timestamp!(
+            "_e{15,22}:myapp.exception|something bad happened|p:normal|t:warning",
+            res.unwrap().as_metric_str()
+        );
+    }
+
+    #[test]
+    fn test_statsd_client_custom_event_with_alert_type_warning_success() {
+        use datadog::builder::EventAlertType;
+
+        let client = StatsdClient::from_sink("myapp", NopMetricSink);
+        let res = client
+            .custom_event("exception", "something bad happened")
+            .with_alert_type(EventAlertType::Success)
+            .try_send();
+
+        assert_eq_ignore_timestamp!(
+            "_e{15,22}:myapp.exception|something bad happened|p:normal|t:success",
+            res.unwrap().as_metric_str()
+        );
+    }
+
+    #[test]
+    fn test_statsd_client_custom_event_with_all() {
+        use datadog::builder::EventAlertType;
+        use datadog::builder::EventPriority;
+
+        let client = StatsdClient::from_sink("myapp", NopMetricSink);
+        let res = client
+            .custom_event("exception", "something bad!")
+            .with_timestamp(1523292353)
+            .with_hostname("example.com")
+            .with_aggregation_key("aggreg_key")
+            .with_priority(EventPriority::Low)
+            .with_src_type("src_type")
+            .with_alert_type(EventAlertType::Error)
+            .with_tag("foo", "bar")
+            .with_tag_value("quux")
+            .try_send();
+
+        assert_eq!(
+            "_e{15,14}:myapp.exception|something bad!|d:1523292353|p:low|t:error|h:example.com|k:aggreg_key|s:src_type|#foo:bar,quux",
+            res.unwrap().as_metric_str()
+        );
+    }
+
+    #[test]
+    fn test_statsd_client_event_max_length_exceeded() {
+        use types::ErrorKind;
+        use datadog::types::MAX_EVENT_LENGTH;
+
+        let mut text = String::new();
+        let letters = &mut ['L', 'O', 'L'].into_iter().cycle();
+        for _ in 1..MAX_EVENT_LENGTH {
+            text.push(*letters.next().unwrap());
+        }
+
+        let client = StatsdClient::from_sink("myapp", NopMetricSink);
+        let res = client.event("exception", &text);
+
+        assert!(res.is_err());
+        assert_eq!(ErrorKind::InvalidInput, res.unwrap_err().kind());
+    }
+
+    // The following tests really just ensure that we've actually
+    // implemented all the traits we're supposed to correctly. If
+    // we hadn't, this wouldn't compile.
+
+    #[test]
+    fn test_statsd_client_as_setted() {
+        let client: Box<Setted> = Box::new(StatsdClient::from_sink("myapp", NopMetricSink));
+
+        client.set("some.set", 5).unwrap();
+    }
+
+    #[test]
+    fn test_statsd_client_as_distributed() {
+        let client: Box<Distributed> = Box::new(StatsdClient::from_sink("myapp", NopMetricSink));
+
+        client.distribution("some.distribution", 20).unwrap();
+    }
+
+    #[test]
+    fn test_statsd_client_as_evented() {
+        let client: Box<Evented> = Box::new(StatsdClient::from_sink("myapp", NopMetricSink));
+
+        client.event("exception", "something bad happened").unwrap();
+    }
+
+    #[test]
+    fn test_statsd_client_as_datadog_metric_client() {
+        let client: Box<DatadogMetricClient> = Box::new(StatsdClient::from_sink("myapp", NopMetricSink));
+
+        client.count("some.counter", 3).unwrap();
+        client.time("some.timer", 198).unwrap();
+        client.gauge("some.gauge", 4).unwrap();
+        client.meter("some.meter", 29).unwrap();
+        client.histogram("some.histogram", 32).unwrap();
+        client.set("some.set", 5).unwrap();
+        client.distribution("some.distribution", 34).unwrap();
+        client.event("exception", "something bad happened").unwrap();
+    }
+}

--- a/src/datadog/mod.rs
+++ b/src/datadog/mod.rs
@@ -1,0 +1,74 @@
+// Cadence - An extensible Statsd client for Rust!
+//
+// Copyright 2015-2017 TSH Labs
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Datadog mextensions for Cadence.
+//!
+//! [Datadog](https://docs.datadoghq.com/developers/dogstatsd/) defines few extensions to the
+//! [Statsd](https://docs.datadoghq.com/developers/dogstatsd/) specification. Notably, two
+//! additional types of metrics: Sets and the recently added Distributions as well as Events.
+//!
+//! This module implement these extensions in the case you are sending metrics to a fully 
+//! compliant DogStatsD //! statsd server such as the 
+//! [Datadog Agent](https://docs.datadoghq.com/agent/).
+//!
+//! These extensions are enabled when using this crate with the `datadog-extensions` feature
+//! enabled.
+//!
+//! ## Features
+//!
+//! * Support for emitting sets and distributions to DogStatsD over UDP.
+//! * Support for emitting events to DogStatsD over UDP.
+//!
+//! ## Usage
+//!
+//! Simple usage of Cadence Datadog extensions is shown below. In this example,
+//! we just import the client, create an instance that will write to some 
+//! imaginary metrics server, and send a few metrics.
+//!
+//! First, make sure you enable the extensions when pulling the dependency. Note the use of the
+//! `datadog-extensions` feature.
+//!
+//! In your `Cargo.toml` file:
+//! ``` toml
+//! [dependencies.cadence]
+//! version = "x.y.z"
+//! features = ["datadog-extensions"]
+//! ```
+//!
+//! ``` rust,no_run
+//! // Import the client.
+//! use cadence::prelude::*;
+//! use cadence::{StatsdClient, UdpMetricSink, DEFAULT_PORT};
+//!
+//! // Create client that will write to the given host over UDP.
+//! //
+//! // Note that you'll probably want to actually handle any errors creating
+//! // the client when you use it for real in your application. We're just
+//! // using .unwrap() here since this is an example!
+//! let host = ("metrics.example.com", DEFAULT_PORT);
+//! let client = StatsdClient::from_udp_host("my.metrics", host).unwrap();
+//!
+//! // Emit metrics!
+//! client.set("mywebsite.users.uniques", 42);
+//! client.distribution("mywebsite.page_render.time", 210);
+//! client.event("exception", "something bad happened");
+//! ```
+pub mod client;
+pub mod types;
+pub mod builder;
+
+#[cfg(feature = "datadog-extensions")]
+pub use self::builder::{EventBuilder, EventPriority, EventAlertType};
+
+#[cfg(feature = "datadog-extensions")]
+pub use self::types::{Distribution, Event, Set};
+
+#[cfg(feature = "datadog-extensions")]
+pub use self::client::{Evented, Distributed, Setted, DatadogMetricClient};

--- a/src/datadog/types.rs
+++ b/src/datadog/types.rs
@@ -1,0 +1,133 @@
+pub use types::Metric;
+use builder::MetricFormatter;
+use datadog::builder::EventFormatter;
+use types::{MetricResult, MetricError, ErrorKind};
+
+pub const MAX_EVENT_LENGTH: usize = 8 * 1024;
+
+/// Sets count the number of unique elements in a group.
+///
+/// See the `Setted` trait for more information.
+#[derive(PartialEq, Eq, Debug, Hash, Clone)]
+pub struct Set {
+    repr: String,
+}
+
+impl Set {
+    pub fn new(prefix: &str, key: &str, value: i64) -> Set {
+        MetricFormatter::set(prefix, key, value).build()
+    }
+}
+
+impl From<String> for Set {
+    fn from(s: String) -> Self {
+        Set { repr: s }
+    }
+}
+
+impl Metric for Set {
+    fn as_metric_str(&self) -> &str {
+        &self.repr
+    }
+}
+
+/// Distributions track values to be computed as statistical
+/// distributions.
+/// 
+/// See the `Distributed` trait for more information.
+#[derive(PartialEq, Eq, Debug, Hash, Clone)]
+pub struct Distribution {
+    repr: String,
+}
+
+impl Distribution {
+    pub fn new(prefix: &str, key: &str, value: i64) -> Set {
+        MetricFormatter::distribution(prefix, key, value).build()
+    }
+}
+
+impl From<String> for Distribution {
+    fn from(s: String) -> Self {
+        Distribution { repr: s }
+    }
+}
+
+impl Metric for Distribution {
+    fn as_metric_str(&self) -> &str {
+        &self.repr
+    }
+}
+
+/// Events are values sent to the datadog event stream and can be
+/// via the Datadog interface.
+///
+/// See the `Evented` trait for more information.
+#[derive(PartialEq, Eq, Debug, Hash, Clone)]
+pub struct Event {
+    repr: String,
+}
+
+impl Event {
+    pub fn new(prefix: &str, title: &str, text: &str) -> MetricResult<Event> {
+        EventFormatter::event(prefix, title, text).build()
+    }
+}
+
+impl From<String> for Event {
+    fn from(s: String) -> Self {
+        Event { repr: s }
+    }
+}
+
+impl Metric for Event {
+    fn as_metric_str(&self) -> &str {
+        &self.repr
+    }
+}
+
+pub(crate) fn max_event_exceeded_error() -> MetricError {
+    MetricError::from((ErrorKind::InvalidInput, "maximum event length exceeded"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Event, Metric, Set, Distribution};
+
+    /// Strips the timestamp which is by default dynamic and then uses regular assert_eq!
+    macro_rules! assert_eq_ignore_timestamp {
+        ($left:expr, $right:expr) => ({
+            use regex::Regex;
+            let re = Regex::new(r"\|d:\d+").unwrap();
+
+            match (&$left, &$right) {
+                (left_val, right_val) => {
+                    let left_wo_timestamp = re.replace_all(*left_val, "");
+                    let right_wo_timestamp = re.replace_all(*right_val, "");
+                    assert_eq!(*left_wo_timestamp, right_wo_timestamp);
+                }
+            }
+        });
+    }
+
+    #[test]
+    fn test_set_to_metric_string() {
+        let set = Set::new("my.app", "test.set", 4);
+        assert_eq!("my.app.test.set:4|s", set.as_metric_str());
+    }
+
+    #[test]
+    fn test_distribution_to_metric_string() {
+        let distribution = Distribution::new("my.app", "test.distribution", 5);
+        assert_eq!("my.app.test.distribution:5|d", distribution.as_metric_str());
+    }
+
+    #[test]
+    fn test_event_to_metric_string() {
+        let event = Event::new("my.app", "boom!", "something bad happened").unwrap();
+
+        assert_eq_ignore_timestamp!(
+            "_e{12,22}:my.app.boom!|something bad happened|p:normal|t:info",
+            event.as_metric_str()
+        );
+    }
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -26,3 +26,11 @@
 //! ```
 
 pub use client::{Counted, Gauged, Histogrammed, Metered, MetricClient, Timed};
+
+#[cfg(feature = "datadog-extensions")]
+pub use datadog::{
+    Setted,
+    Distributed,
+    Evented,
+    DatadogMetricClient,
+ };

--- a/src/types.rs
+++ b/src/types.rs
@@ -233,7 +233,6 @@ pub type MetricResult<T> = Result<T, MetricError>;
 
 #[cfg(test)]
 mod tests {
-
     use std::io;
     use std::error::Error;
     use super::{Counter, ErrorKind, Gauge, Histogram, Meter, Metric, MetricError, Timer};


### PR DESCRIPTION
## Optional full Datadog compatibility. (Proposal)

First of all, I'm sorry for opening this huge PR xD. Please don't hate me (I hate long PRs) I promise is not as bad as it looks ;) It's mostly docs and tests.I am working on a prototype at work and we use Datadog extensively,during my research for a Stastd client I've found this awesome crate and I loved it! But it did not support (understandably) Datadog specific extensions, so after a bit of consideration, I decided that instead of going and creating my own client wrapping by Cadence, I could implement a backwards compatible, optional extension, that would turn Cadence in a fully fledged Datadog client when requested.

This PR implements a proposal of such functionality.

- I talked to Datadog guys about it and they were thrilled with it, they even sponsored me an account. So if you decide to move forward with this, we can iterate until reaches a mergeable state. Then, we can list cadence in the Datadog page as the first fully compliant Rust client.
- I'm still missing Datadog "Service Checks" functionality but I consider I have something worthy to show and I just wanted to see your opinion on it folks.
- I'm not really sure if the `size_hint` for events makes sense, could you
give it a detailed look?
- There is still a bunch of duplication between `MetricBuilder` and
`EventBuilder` I guess we can fix that before we merge.

Without further ado, the serious stuff:

Implemented a set of extensions under the optional `datadog-extensions` Cargo feature that, when enabled, will turn Cadence into a fully fledged Datadog client.

All the extensions were based on the implementation of the official DogStatsd client.

- Distributions: (Also called Global Percentiles): Very similar to histograms but with the key difference that they histograms percentiles are calculated server-side (by sending sketches of the histogram data per host to the server), instead of at the host, making it possible to compute accurate DogstatsD
percentiles across hosts.
- Sets: Which are not a Datadog only feature but are not currently supported. Sets allow counting unique occurrences of events between flushes, using a Set to store all occurring events.
- Events: Events to be sent to the Datadog event stream. Useful to report things like exceptions happening in your system along with their stack-traces.

All of the implementation, when possible, was added inside a `datadog` module compiled only when the crate is required with the `datadog-extensions` enabled. Changes in the current outer modules where mostly crate-level visibility tweaks in order to reuse as much code as possible.

For supporting Sets and Distributions two new traits are added `Setted` and `Distributed` (following the naming conventions observed in the code, we can change those names in case we don't like them). Both traits follow the same conventions seen in the rest of the traits implemented by `StatsdClient`, as in they have a `set` and `distribution` methods with their respective `*_with_tags`
variation that returns a builder.

In order to ease the usage of all the features including the Datadog extensions, a new `DatadogMetricClient` is added to make possible bring all the functionality pulling a single trait. Very much as `MetricClient` does.

In order to add support for datadog events and in the same vein of `Setted` and `Distributed` an `Evented` trait is added exposing two methods `event` and `custom_event` which returns a builder. Rationale behind this name is that events can be customized mush more than just adding tags so the
`*_with_tags` was not a suitable anymore, again, id we decide to change for something better, I'm up for that too.

I've written as much tests as I could, and to be honest, coming from Ruby: I think I exceeded a bit xD. Anyways, all the tests follow the conventions found in the current implementation.

Respective documentation is also added.