### PR TITLE
Added support for Statsd Set metrics.

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -40,6 +40,7 @@ enum MetricType {
     Gauge,
     Meter,
     Histogram,
+    Set
 }
 
 impl fmt::Display for MetricType {
@@ -50,6 +51,7 @@ impl fmt::Display for MetricType {
             MetricType::Gauge => "g".fmt(f),
             MetricType::Meter => "m".fmt(f),
             MetricType::Histogram => "h".fmt(f),
+            MetricType::Set => "s".fmt(f),
         }
     }
 }
@@ -89,6 +91,10 @@ where
 
     pub(crate) fn histogram(prefix: &'a str, key: &'a str, val: u64) -> Self {
         Self::from_u64(prefix, key, val, MetricType::Histogram)
+    }
+
+    pub(crate) fn set(prefix: &'a str, key: &'a str, val: i64) -> Self {
+        Self::from_i64(prefix, key, val, MetricType::Set)
     }
 
     fn from_u64(prefix: &'a str, key: &'a str, val: u64, type_: MetricType) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -345,6 +345,7 @@
 //! client.count("my.counter.thing", 29);
 //! client.time("my.service.call", 214);
 //! client.incr("some.event");
+//! client.set("users.uniques", 42);
 //! ```
 //!
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -25,4 +25,4 @@
 //! client.histogram("some.histogram", 89).unwrap();
 //! ```
 
-pub use client::{Counted, Gauged, Histogrammed, Metered, MetricClient, Timed};
+pub use client::{Counted, Gauged, Histogrammed, Setted, Metered, MetricClient, Timed};

--- a/src/types.rs
+++ b/src/types.rs
@@ -158,6 +158,32 @@ impl Metric for Histogram {
     }
 }
 
+/// Sets count the number of unique elements in a group.
+///
+/// See the `Setted` trait for more information.
+#[derive(PartialEq, Eq, Debug, Hash, Clone)]
+pub struct Set {
+    repr: String,
+}
+
+impl Set {
+    pub fn new(prefix: &str, key: &str, value: i64) -> Set {
+        MetricFormatter::set(prefix, key, value).build()
+    }
+}
+
+impl From<String> for Set {
+    fn from(s: String) -> Self {
+        Set { repr: s }
+    }
+}
+
+impl Metric for Set {
+    fn as_metric_str(&self) -> &str {
+        &self.repr
+    }
+}
+
 /// Potential categories an error from this library falls into.
 #[derive(PartialEq, Eq, Debug, Hash, Clone, Copy)]
 pub enum ErrorKind {
@@ -236,7 +262,7 @@ mod tests {
 
     use std::io;
     use std::error::Error;
-    use super::{Counter, ErrorKind, Gauge, Histogram, Meter, Metric, MetricError, Timer};
+    use super::{Counter, ErrorKind, Gauge, Histogram, Meter, Metric, MetricError, Timer, Set};
 
     #[test]
     fn test_counter_to_metric_string() {
@@ -266,6 +292,12 @@ mod tests {
     fn test_histogram_to_metric_string() {
         let histogram = Histogram::new("my.app", "test.histogram", 45);
         assert_eq!("my.app.test.histogram:45|h", histogram.as_metric_str());
+    }
+
+    #[test]
+    fn test_set_to_metric_string() {
+        let set = Set::new("my.app", "test.set", 4);
+        assert_eq!("my.app.test.set:4|s", set.as_metric_str());
     }
 
     #[test]


### PR DESCRIPTION
As discussed in https://github.com/tshlabs/cadence/pull/70 this PR implements the Set metric types.

Next, is creating that SHIM for supporting Datadog.

//cc @berkus 

Details

- Set infrastructure.
- Tests.