### PR TITLE
Add trait for exposing client extension points

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -9,7 +9,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use client::StatsdClient;
+use client::{MetricBackend, StatsdClient};
 use std::fmt::{self, Write};
 use std::marker::PhantomData;
 use types::{Metric, MetricError, MetricResult};

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -1,0 +1,17 @@
+// Cadence - An extensible Statsd client for Rust!
+//
+// Copyright 2018 TSH Labs
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Extension points for the Cadence library
+//!
+//! Libraries wishing to make use of Cadence for sending metrics to
+//! a Statsd server but needing more control over how the metrics are
+//! built and formatted can make use these extension points.
+
+pub use client::MetricBackend;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 // Cadence - An extensible Statsd client for Rust!
 //
-// Copyright 2015-2017 TSH Labs
+// Copyright 2015-2018 TSH Labs
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -367,6 +367,7 @@ pub use self::types::{Counter, ErrorKind, Gauge, Histogram, Meter, Metric, Metri
                       MetricResult, Set, Timer};
 
 pub mod prelude;
+pub mod ext;
 mod builder;
 mod client;
 mod io;


### PR DESCRIPTION
Add a trait for exposing potential extension points for 3rd party
libraries that wish to implement custom metric types. The trait is
not exposed by default and only available via the `ext` module.

Fixes #73