### PR TITLE
Replace uses of crossbeam MsQueue with crossbeam_channel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0/MIT"
 keywords = ["statsd", "metrics"]
 
 [dependencies]
-crossbeam = "0.3.2"
+crossbeam-channel = "0.3.8"
 
 [lib]
 name = "cadence"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,7 +353,7 @@
 
 #![forbid(unsafe_code)]
 
-extern crate crossbeam;
+extern crate crossbeam_channel;
 
 pub const DEFAULT_PORT: u16 = 8125;
 


### PR DESCRIPTION
Replace all uses of crossbeam MsQueue (from 0.3 series) with senders
and receivers from the new crossbeam_channel crate. Use an unbounded
channel to keep the same behavior as MsQueue.

Keep the idea of using "posion pill" messages to allow the sink and
any workers or threads to be easily stopped when the sink is dropped.
Additionally, this makes testing easier.

Fixes #79