### PR TITLE
Allow empty prefix

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -266,38 +266,74 @@ mod tests {
 
     #[test]
     fn test_counter_to_metric_string() {
-        let counter = Counter::new("my.app", "test.counter", 4);
+        let counter = Counter::new("my.app.", "test.counter", 4);
         assert_eq!("my.app.test.counter:4|c", counter.as_metric_str());
     }
 
     #[test]
+    fn test_counter_no_prefix_to_metric_string() {
+        let counter = Counter::new("", "test.counter", 4);
+        assert_eq!("test.counter:4|c", counter.as_metric_str());
+    }
+
+    #[test]
     fn test_timer_to_metric_string() {
-        let timer = Timer::new("my.app", "test.timer", 34);
+        let timer = Timer::new("my.app.", "test.timer", 34);
         assert_eq!("my.app.test.timer:34|ms", timer.as_metric_str());
     }
 
     #[test]
+    fn test_timer_no_prefix_to_metric_string() {
+        let timer = Timer::new("", "test.timer", 34);
+        assert_eq!("test.timer:34|ms", timer.as_metric_str());
+    }
+
+    #[test]
     fn test_gauge_to_metric_string() {
-        let gauge = Gauge::new("my.app", "test.gauge", 2);
+        let gauge = Gauge::new("my.app.", "test.gauge", 2);
         assert_eq!("my.app.test.gauge:2|g", gauge.as_metric_str());
     }
 
     #[test]
+    fn test_gauge_no_prefix_to_metric_string() {
+        let gauge = Gauge::new("", "test.gauge", 2);
+        assert_eq!("test.gauge:2|g", gauge.as_metric_str());
+    }
+
+    #[test]
     fn test_meter_to_metric_string() {
-        let meter = Meter::new("my.app", "test.meter", 5);
+        let meter = Meter::new("my.app.", "test.meter", 5);
         assert_eq!("my.app.test.meter:5|m", meter.as_metric_str());
     }
 
     #[test]
+    fn test_meter_no_prefix_to_metric_string() {
+        let meter = Meter::new("", "test.meter", 5);
+        assert_eq!("test.meter:5|m", meter.as_metric_str());
+    }
+
+    #[test]
     fn test_histogram_to_metric_string() {
-        let histogram = Histogram::new("my.app", "test.histogram", 45);
+        let histogram = Histogram::new("my.app.", "test.histogram", 45);
         assert_eq!("my.app.test.histogram:45|h", histogram.as_metric_str());
     }
 
     #[test]
+    fn test_histogram_no_prefix_to_metric_string() {
+        let histogram = Histogram::new("", "test.histogram", 45);
+        assert_eq!("test.histogram:45|h", histogram.as_metric_str());
+    }
+
+    #[test]
     fn test_set_to_metric_string() {
-        let set = Set::new("my.app", "test.set", 4);
+        let set = Set::new("my.app.", "test.set", 4);
         assert_eq!("my.app.test.set:4|s", set.as_metric_str());
+    }
+
+    #[test]
+    fn test_set_no_prefix_to_metric_string() {
+        let set = Set::new("", "test.set", 4);
+        assert_eq!("test.set:4|s", set.as_metric_str());
     }
 
     #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -38,35 +38,35 @@ fn new_queuing_buffered_udp_client(prefix: &str) -> StatsdClient {
 #[test]
 fn test_statsd_client_incr() {
     let client = new_nop_client("client.test");
-    let expected = Counter::new("client.test", "counter.key", 1);
+    let expected = Counter::new("client.test.", "counter.key", 1);
     assert_eq!(expected, client.incr("counter.key").unwrap());
 }
 
 #[test]
 fn test_statsd_client_decr() {
     let client = new_nop_client("client.test");
-    let expected = Counter::new("client.test", "counter.key", -1);
+    let expected = Counter::new("client.test.", "counter.key", -1);
     assert_eq!(expected, client.decr("counter.key").unwrap());
 }
 
 #[test]
 fn test_statsd_client_count() {
     let client = new_nop_client("client.test");
-    let expected = Counter::new("client.test", "counter.key", 42);
+    let expected = Counter::new("client.test.", "counter.key", 42);
     assert_eq!(expected, client.count("counter.key", 42).unwrap());
 }
 
 #[test]
 fn test_statsd_client_time() {
     let client = new_nop_client("client.test");
-    let expected = Timer::new("client.test", "timer.key", 25);
+    let expected = Timer::new("client.test.", "timer.key", 25);
     assert_eq!(expected, client.time("timer.key", 25).unwrap());
 }
 
 #[test]
 fn test_statsd_client_time_duration() {
     let client = new_nop_client("client.test");
-    let expected = Timer::new("client.test", "timer.key", 35);
+    let expected = Timer::new("client.test.", "timer.key", 35);
     assert_eq!(
         expected,
         client
@@ -78,28 +78,28 @@ fn test_statsd_client_time_duration() {
 #[test]
 fn test_statsd_client_gauge() {
     let client = new_nop_client("client.test");
-    let expected = Gauge::new("client.test", "gauge.key", 5);
+    let expected = Gauge::new("client.test.", "gauge.key", 5);
     assert_eq!(expected, client.gauge("gauge.key", 5).unwrap());
 }
 
 #[test]
 fn test_statsd_client_mark() {
     let client = new_nop_client("client.test");
-    let expected = Meter::new("client.test", "meter.key", 1);
+    let expected = Meter::new("client.test.", "meter.key", 1);
     assert_eq!(expected, client.mark("meter.key").unwrap());
 }
 
 #[test]
 fn test_statsd_client_meter() {
     let client = new_nop_client("client.test");
-    let expected = Meter::new("client.test", "meter.key", 7);
+    let expected = Meter::new("client.test.", "meter.key", 7);
     assert_eq!(expected, client.meter("meter.key", 7).unwrap());
 }
 
 #[test]
 fn test_statsd_client_histogram() {
     let client = new_nop_client("client.test");
-    let expected = Histogram::new("client.test", "histogram.key", 20);
+    let expected = Histogram::new("client.test.", "histogram.key", 20);
     assert_eq!(expected, client.histogram("histogram.key", 20).unwrap());
 }
 


### PR DESCRIPTION
For my purposes, I want to create stats without a prefix. If I try to pass in an empty string, names get created with a preceding dot.

This adds a check for an empty prefix when building base metrics.