### PR TITLE
Convert UDS writers to use UnixDatagram instead of UnixStream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ edition = "2018"
 [dependencies]
 crossbeam-channel = "0.3.8"
 
+[dev-dependencies]
+tempdir = "0.3.7"
+
 [lib]
 name = "cadence"
 path = "src/lib.rs"

--- a/README.md
+++ b/README.md
@@ -346,11 +346,11 @@ client.set("users.uniques", 42);
 Cadence also supports using UDS with the `UdsMetricSink`:
 
 ``` rust
-use std::os::unix::net::UnixStream;
+use std::os::unix::net::UnixDatagram;
 use cadence::prelude::*;
 use cadence::{StatsdClient, UdsMetricSink};
 
-let socket = UnixStream::connect("/tmp/sock").unwrap();
+let socket = UnixDatagram::bind("/tmp/sock").unwrap();
 socket.set_nonblocking(true).unwrap();
 let sink = UdsMetricSink::from(socket);
 let client = StatsdClient::from_sink("my.prefix", sink);

--- a/README.md
+++ b/README.md
@@ -351,9 +351,8 @@ use cadence::prelude::*;
 use cadence::{StatsdClient, UdsMetricSink};
 
 let socket = UnixDatagram::unbound();
-socket.connect("/tmp/sock").unwrap();
 socket.set_nonblocking(true).unwrap();
-let sink = UdsMetricSink::from(socket);
+let sink = UdsMetricSink::from(socket, "/tmp/sock");
 let client = StatsdClient::from_sink("my.prefix", sink);
 
 client.count("my.counter.thing", 29);

--- a/README.md
+++ b/README.md
@@ -350,7 +350,8 @@ use std::os::unix::net::UnixDatagram;
 use cadence::prelude::*;
 use cadence::{StatsdClient, UdsMetricSink};
 
-let socket = UnixDatagram::bind("/tmp/sock").unwrap();
+let socket = UnixDatagram::unbound();
+socket.connect("/tmp/sock").unwrap();
 socket.set_nonblocking(true).unwrap();
 let sink = UdsMetricSink::from(socket);
 let client = StatsdClient::from_sink("my.prefix", sink);

--- a/src/client.rs
+++ b/src/client.rs
@@ -10,13 +10,12 @@
 
 use std::fmt;
 use std::net::{ToSocketAddrs, UdpSocket};
-use std::os::unix::net::UnixStream;
 use std::panic::RefUnwindSafe;
 use std::sync::Arc;
 use std::time::Duration;
 
 use crate::builder::{MetricBuilder, MetricFormatter};
-use crate::sinks::{MetricSink, UdpMetricSink, UdsMetricSink};
+use crate::sinks::{MetricSink, UdpMetricSink};
 use crate::types::{
     Counter, ErrorKind, Gauge, Histogram, Meter, Metric, MetricError, MetricResult, Set, Timer,
 };
@@ -187,7 +186,11 @@ pub trait Histogrammed {
 
     /// Record a single histogram value with the given key and return a
     /// `MetricBuilder` that can be used to add tags to the metric.
-    fn histogram_with_tags<'a>(&'a self, key: &'a str, value: u64) -> MetricBuilder<'_, '_, Histogram>;
+    fn histogram_with_tags<'a>(
+        &'a self,
+        key: &'a str,
+        value: u64,
+    ) -> MetricBuilder<'_, '_, Histogram>;
 }
 
 /// Trait for recording set values.
@@ -744,7 +747,11 @@ impl Metered for StatsdClient {
 }
 
 impl Histogrammed for StatsdClient {
-    fn histogram_with_tags<'a>(&'a self, key: &'a str, value: u64) -> MetricBuilder<'_, '_, Histogram> {
+    fn histogram_with_tags<'a>(
+        &'a self,
+        key: &'a str,
+        value: u64,
+    ) -> MetricBuilder<'_, '_, Histogram> {
         let fmt = MetricFormatter::histogram(&self.prefix, key, value);
         MetricBuilder::new(fmt, self)
     }
@@ -1013,7 +1020,8 @@ mod tests {
 
     #[test]
     fn test_statsd_client_as_histogrammed() {
-        let client: Box<dyn Histogrammed> = Box::new(StatsdClient::from_sink("prefix", NopMetricSink));
+        let client: Box<dyn Histogrammed> =
+            Box::new(StatsdClient::from_sink("prefix", NopMetricSink));
 
         client.histogram("some.histogram", 4).unwrap();
     }
@@ -1027,7 +1035,8 @@ mod tests {
 
     #[test]
     fn test_statsd_client_as_metric_client() {
-        let client: Box<dyn MetricClient> = Box::new(StatsdClient::from_sink("prefix", NopMetricSink));
+        let client: Box<dyn MetricClient> =
+            Box::new(StatsdClient::from_sink("prefix", NopMetricSink));
 
         client.count("some.counter", 3).unwrap();
         client.time("some.timer", 198).unwrap();

--- a/src/client.rs
+++ b/src/client.rs
@@ -186,11 +186,7 @@ pub trait Histogrammed {
 
     /// Record a single histogram value with the given key and return a
     /// `MetricBuilder` that can be used to add tags to the metric.
-    fn histogram_with_tags<'a>(
-        &'a self,
-        key: &'a str,
-        value: u64,
-    ) -> MetricBuilder<'_, '_, Histogram>;
+    fn histogram_with_tags<'a>(&'a self, key: &'a str, value: u64) -> MetricBuilder<'_, '_, Histogram>;
 }
 
 /// Trait for recording set values.
@@ -747,11 +743,7 @@ impl Metered for StatsdClient {
 }
 
 impl Histogrammed for StatsdClient {
-    fn histogram_with_tags<'a>(
-        &'a self,
-        key: &'a str,
-        value: u64,
-    ) -> MetricBuilder<'_, '_, Histogram> {
+    fn histogram_with_tags<'a>(&'a self, key: &'a str, value: u64) -> MetricBuilder<'_, '_, Histogram> {
         let fmt = MetricFormatter::histogram(&self.prefix, key, value);
         MetricBuilder::new(fmt, self)
     }
@@ -1020,8 +1012,7 @@ mod tests {
 
     #[test]
     fn test_statsd_client_as_histogrammed() {
-        let client: Box<dyn Histogrammed> =
-            Box::new(StatsdClient::from_sink("prefix", NopMetricSink));
+        let client: Box<dyn Histogrammed> = Box::new(StatsdClient::from_sink("prefix", NopMetricSink));
 
         client.histogram("some.histogram", 4).unwrap();
     }
@@ -1035,8 +1026,7 @@ mod tests {
 
     #[test]
     fn test_statsd_client_as_metric_client() {
-        let client: Box<dyn MetricClient> =
-            Box::new(StatsdClient::from_sink("prefix", NopMetricSink));
+        let client: Box<dyn MetricClient> = Box::new(StatsdClient::from_sink("prefix", NopMetricSink));
 
         client.count("some.counter", 3).unwrap();
         client.time("some.timer", 198).unwrap();

--- a/src/io.rs
+++ b/src/io.rs
@@ -11,7 +11,6 @@
 use std::io;
 use std::io::{BufWriter, Write};
 use std::net::{SocketAddr, UdpSocket};
-use std::os::unix::net::UnixDatagram;
 use std::str;
 
 #[derive(Debug, Default)]
@@ -112,35 +111,16 @@ pub(crate) struct UdpWriteAdapter {
 
 impl UdpWriteAdapter {
     pub(crate) fn new(addr: SocketAddr, socket: UdpSocket) -> UdpWriteAdapter {
-        UdpWriteAdapter { addr, socket }
+        UdpWriteAdapter {
+            addr,
+            socket,
+        }
     }
 }
 
 impl Write for UdpWriteAdapter {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.socket.send_to(buf, &self.addr)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
-    }
-}
-
-/// Adapter for writing to a `UdsSocket` via the `Write` trait
-#[derive(Debug)]
-pub(crate) struct UdsWriteAdapter {
-    socket: UnixDatagram,
-}
-
-impl UdsWriteAdapter {
-    pub(crate) fn new(socket: UnixDatagram) -> UdsWriteAdapter {
-        UdsWriteAdapter { socket }
-    }
-}
-
-impl Write for UdsWriteAdapter {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.socket.send(buf)
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/src/io.rs
+++ b/src/io.rs
@@ -11,6 +11,7 @@
 use std::io;
 use std::io::{BufWriter, Write};
 use std::net::{SocketAddr, UdpSocket};
+use std::os::unix::net::UnixDatagram;
 use std::str;
 
 #[derive(Debug, Default)]
@@ -111,16 +112,35 @@ pub(crate) struct UdpWriteAdapter {
 
 impl UdpWriteAdapter {
     pub(crate) fn new(addr: SocketAddr, socket: UdpSocket) -> UdpWriteAdapter {
-        UdpWriteAdapter {
-            addr,
-            socket,
-        }
+        UdpWriteAdapter { addr, socket }
     }
 }
 
 impl Write for UdpWriteAdapter {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.socket.send_to(buf, &self.addr)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Adapter for writing to a `UdsSocket` via the `Write` trait
+#[derive(Debug)]
+pub(crate) struct UdsWriteAdapter {
+    socket: UnixDatagram,
+}
+
+impl UdsWriteAdapter {
+    pub(crate) fn new(socket: UnixDatagram) -> UdsWriteAdapter {
+        UdsWriteAdapter { socket }
+    }
+}
+
+impl Write for UdsWriteAdapter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.socket.send(buf)
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,11 +354,11 @@
 //!
 //!
 //! ``` rust,no_run
-//! use std::os::unix::net::UnixStream;
+//! use std::os::unix::net::UnixDatagram;
 //! use cadence::prelude::*;
 //! use cadence::{StatsdClient, UdsMetricSink};
 //!
-//! let socket = UnixStream::connect("/tmp/sock").unwrap();
+//! let socket = UnixDatagram::bind("/tmp/sock").unwrap();
 //! socket.set_nonblocking(true).unwrap();
 //! let sink = UdsMetricSink::from(socket);
 //! let client = StatsdClient::from_sink("my.prefix", sink);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,9 +359,8 @@
 //! use cadence::{StatsdClient, UdsMetricSink};
 //!
 //! let socket = UnixDatagram::unbound().unwrap();
-//! socket.connect("/tmp/sock").unwrap();
 //! socket.set_nonblocking(true).unwrap();
-//! let sink = UdsMetricSink::from(socket);
+//! let sink = UdsMetricSink::from(socket, "/tmp/sock");
 //! let client = StatsdClient::from_sink("my.prefix", sink);
 //!
 //! client.count("my.counter.thing", 29);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,7 +358,8 @@
 //! use cadence::prelude::*;
 //! use cadence::{StatsdClient, UdsMetricSink};
 //!
-//! let socket = UnixDatagram::bind("/tmp/sock").unwrap();
+//! let socket = UnixDatagram::unbound().unwrap();
+//! socket.connect("/tmp/sock").unwrap();
 //! socket.set_nonblocking(true).unwrap();
 //! let sink = UdsMetricSink::from(socket);
 //! let client = StatsdClient::from_sink("my.prefix", sink);

--- a/src/sinks/uds.rs
+++ b/src/sinks/uds.rs
@@ -72,6 +72,8 @@ impl UdsMetricSink {
 
 impl MetricSink for UdsMetricSink {
     fn emit(&self, metric: &str) -> io::Result<usize> {
+        // TODO: We should reconnect if the socket is ever disconnected.
+        // Example similar issue: https://github.com/brightcove/hot-shots/issues/114
         self.socket.send(metric.as_bytes())
     }
 }

--- a/src/sinks/uds.rs
+++ b/src/sinks/uds.rs
@@ -79,7 +79,7 @@ impl MetricSink for UdsMetricSink {
     }
 }
 
-/// Adapter for writing to a `UdsSocket` via the `Write` trait
+/// Adapter for writing to a `UnixDatagram` socket via the `Write` trait
 #[derive(Debug)]
 pub(crate) struct UdsWriteAdapter {
     socket: UnixDatagram,
@@ -213,6 +213,7 @@ mod tests {
     #[test]
     fn test_non_blocking_uds_metric_sink() {
         let socket = UnixDatagram::unbound().unwrap();
+        socket.set_nonblocking(true).unwrap();
         let tmp_dir = TempDir::new("testing").unwrap();
         let file_path = tmp_dir.path().join("tmp.sock");
         // Create a listener.

--- a/src/sinks/uds.rs
+++ b/src/sinks/uds.rs
@@ -46,7 +46,8 @@ impl UdsMetricSink {
     /// use std::os::unix::net::UnixDatagram;
     /// use cadence::UdsMetricSink;
     ///
-    /// let socket = UnixDatagram::bind("/tmp/sock").unwrap();
+    /// let socket = UnixDatagram::unbound().unwrap();
+    /// socket.connect("/tmp/sock").unwrap();
     /// let sink = UdsMetricSink::from(socket);
     /// ```
     ///
@@ -55,15 +56,12 @@ impl UdsMetricSink {
     ///
     /// # Non-blocking Example
     ///
-    /// Note that putting the UDS socket into non-blocking mode is the
-    /// default when sink and socket are automatically created with the
-    /// `StatsdClient::from_uds_path` method.
-    ///
     /// ```no_run
     /// use std::os::unix::net::UnixDatagram;
     /// use cadence::UdsMetricSink;
     ///
-    /// let socket = UnixDatagram::bind("/tmp/sock").unwrap();
+    /// let socket = UnixDatagram::unbound().unwrap();
+    /// socket.connect("/tmp/sock").unwrap();
     /// socket.set_nonblocking(true).unwrap();
     /// let sink = UdsMetricSink::from(socket);
     /// ```
@@ -116,7 +114,8 @@ impl BufferedUdsMetricSink {
     /// use std::os::unix::net::UnixDatagram;
     /// use cadence::BufferedUdsMetricSink;
     ///
-    /// let socket = UnixDatagram::bind("/tmp/sock").unwrap();
+    /// let socket = UnixDatagram::unbound().unwrap();
+    /// socket.connect("/tmp/sock").unwrap();
     /// let sink = BufferedUdsMetricSink::from(socket);
     /// ```
     pub fn from(socket: UnixDatagram) -> BufferedUdsMetricSink {
@@ -142,7 +141,8 @@ impl BufferedUdsMetricSink {
     /// use std::os::unix::net::UnixDatagram;
     /// use cadence::BufferedUdsMetricSink;
     ///
-    /// let socket = UnixDatagram::bind("/tmp/sock").unwrap();
+    /// let socket = UnixDatagram::unbound().unwrap();
+    /// socket.connect("/tmp/sock").unwrap();
     /// let sink = BufferedUdsMetricSink::with_capacity(socket, 1432);
     /// ```
     pub fn with_capacity(socket: UnixDatagram, cap: usize) -> BufferedUdsMetricSink {
@@ -172,7 +172,7 @@ mod tests {
     }
 
     #[test]
-    fn test_non_blocking_udp_metric_sink() {
+    fn test_non_blocking_uds_metric_sink() {
         let (socket, _recv) = UnixDatagram::pair().unwrap();
         socket.set_nonblocking(true).unwrap();
         let sink = UdsMetricSink::from(socket);
@@ -180,7 +180,7 @@ mod tests {
     }
 
     #[test]
-    fn test_buffered_udp_metric_sink() {
+    fn test_buffered_uds_metric_sink() {
         let (socket, _recv) = UnixDatagram::pair().unwrap();
         // Set the capacity of the buffer such that we know it will
         // be flushed as a response to the metrics we're writing.

--- a/src/sinks/uds.rs
+++ b/src/sinks/uds.rs
@@ -9,9 +9,10 @@
 use std::io;
 use std::io::Write;
 use std::os::unix::net::UnixDatagram;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
-use crate::io::{MultiLineWriter, UdsWriteAdapter};
+use crate::io::MultiLineWriter;
 use crate::sinks::core::MetricSink;
 
 // Default size of the buffer for buffered metric sinks. This
@@ -32,6 +33,7 @@ const DEFAULT_BUFFER_SIZE: usize = 512;
 #[derive(Debug)]
 pub struct UdsMetricSink {
     socket: UnixDatagram,
+    path: PathBuf,
 }
 
 impl UdsMetricSink {
@@ -47,8 +49,7 @@ impl UdsMetricSink {
     /// use cadence::UdsMetricSink;
     ///
     /// let socket = UnixDatagram::unbound().unwrap();
-    /// socket.connect("/tmp/sock").unwrap();
-    /// let sink = UdsMetricSink::from(socket);
+    /// let sink = UdsMetricSink::from(socket, "/tmp/sock");
     /// ```
     ///
     /// To send metrics over a non-blocking socket, simply put the socket
@@ -61,20 +62,46 @@ impl UdsMetricSink {
     /// use cadence::UdsMetricSink;
     ///
     /// let socket = UnixDatagram::unbound().unwrap();
-    /// socket.connect("/tmp/sock").unwrap();
     /// socket.set_nonblocking(true).unwrap();
-    /// let sink = UdsMetricSink::from(socket);
+    /// let sink = UdsMetricSink::from(socket, "/tmp/sock");
     /// ```
-    pub fn from(socket: UnixDatagram) -> UdsMetricSink {
-        UdsMetricSink { socket: socket }
+    pub fn from<P: AsRef<Path>>(socket: UnixDatagram, path: P) -> UdsMetricSink {
+        UdsMetricSink {
+            socket: socket,
+            path: path.as_ref().to_path_buf(),
+        }
     }
 }
 
 impl MetricSink for UdsMetricSink {
     fn emit(&self, metric: &str) -> io::Result<usize> {
-        // TODO: We should reconnect if the socket is ever disconnected.
-        // Example similar issue: https://github.com/brightcove/hot-shots/issues/114
-        self.socket.send(metric.as_bytes())
+        self.socket.send_to(metric.as_bytes(), self.path.as_path())
+    }
+}
+
+/// Adapter for writing to a `UdsSocket` via the `Write` trait
+#[derive(Debug)]
+pub(crate) struct UdsWriteAdapter {
+    socket: UnixDatagram,
+    path: PathBuf,
+}
+
+impl UdsWriteAdapter {
+    fn new<P: AsRef<Path>>(socket: UnixDatagram, path: P) -> UdsWriteAdapter {
+        UdsWriteAdapter {
+            socket: socket,
+            path: path.as_ref().to_path_buf(),
+        }
+    }
+}
+
+impl Write for UdsWriteAdapter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.socket.send_to(buf, self.path.as_path())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
     }
 }
 
@@ -117,11 +144,10 @@ impl BufferedUdsMetricSink {
     /// use cadence::BufferedUdsMetricSink;
     ///
     /// let socket = UnixDatagram::unbound().unwrap();
-    /// socket.connect("/tmp/sock").unwrap();
-    /// let sink = BufferedUdsMetricSink::from(socket);
+    /// let sink = BufferedUdsMetricSink::from(socket, "/tmp/sock");
     /// ```
-    pub fn from(socket: UnixDatagram) -> BufferedUdsMetricSink {
-        Self::with_capacity(socket, DEFAULT_BUFFER_SIZE)
+    pub fn from<P: AsRef<Path>>(socket: UnixDatagram, path: P) -> BufferedUdsMetricSink {
+        Self::with_capacity(socket, path, DEFAULT_BUFFER_SIZE)
     }
 
     /// Construct a new `BufferedUdsMetricSink` instance with a custom
@@ -144,12 +170,18 @@ impl BufferedUdsMetricSink {
     /// use cadence::BufferedUdsMetricSink;
     ///
     /// let socket = UnixDatagram::unbound().unwrap();
-    /// socket.connect("/tmp/sock").unwrap();
-    /// let sink = BufferedUdsMetricSink::with_capacity(socket, 1432);
+    /// let sink = BufferedUdsMetricSink::with_capacity(socket, "/tmp/sock", 1432);
     /// ```
-    pub fn with_capacity(socket: UnixDatagram, cap: usize) -> BufferedUdsMetricSink {
+    pub fn with_capacity<P: AsRef<Path>>(
+        socket: UnixDatagram,
+        path: P,
+        cap: usize,
+    ) -> BufferedUdsMetricSink {
         BufferedUdsMetricSink {
-            buffer: Mutex::new(MultiLineWriter::new(cap, UdsWriteAdapter::new(socket))),
+            buffer: Mutex::new(MultiLineWriter::new(
+                cap,
+                UdsWriteAdapter::new(socket, path),
+            )),
         }
     }
 }
@@ -165,28 +197,40 @@ impl MetricSink for BufferedUdsMetricSink {
 mod tests {
     use super::{BufferedUdsMetricSink, MetricSink, UdsMetricSink};
     use std::os::unix::net::UnixDatagram;
+    use tempdir::TempDir;
 
     #[test]
     fn test_uds_metric_sink() {
-        let (socket, _recv) = UnixDatagram::pair().unwrap();
-        let sink = UdsMetricSink::from(socket);
+        let socket = UnixDatagram::unbound().unwrap();
+        let tmp_dir = TempDir::new("testing").unwrap();
+        let file_path = tmp_dir.path().join("tmp.sock");
+        // Create a listener.
+        let _listener = UnixDatagram::bind(&file_path);
+        let sink = UdsMetricSink::from(socket, file_path);
         assert_eq!(7, sink.emit("buz:1|m").unwrap());
     }
 
     #[test]
     fn test_non_blocking_uds_metric_sink() {
-        let (socket, _recv) = UnixDatagram::pair().unwrap();
-        socket.set_nonblocking(true).unwrap();
-        let sink = UdsMetricSink::from(socket);
+        let socket = UnixDatagram::unbound().unwrap();
+        let tmp_dir = TempDir::new("testing").unwrap();
+        let file_path = tmp_dir.path().join("tmp.sock");
+        // Create a listener.
+        let _listener = UnixDatagram::bind(&file_path);
+        let sink = UdsMetricSink::from(socket, file_path);
         assert_eq!(7, sink.emit("baz:1|m").unwrap());
     }
 
     #[test]
     fn test_buffered_uds_metric_sink() {
-        let (socket, _recv) = UnixDatagram::pair().unwrap();
+        let socket = UnixDatagram::unbound().unwrap();
+        let tmp_dir = TempDir::new("testing").unwrap();
+        let file_path = tmp_dir.path().join("tmp.sock");
+        // Create a listener.
+        let _listener = UnixDatagram::bind(&file_path);
         // Set the capacity of the buffer such that we know it will
         // be flushed as a response to the metrics we're writing.
-        let sink = BufferedUdsMetricSink::with_capacity(socket, 16);
+        let sink = BufferedUdsMetricSink::with_capacity(socket, file_path, 16);
 
         // Note that we're including an extra byte in the expected
         // number written since each metric is followed by a '\n' at


### PR DESCRIPTION
https://github.com/tshlabs/cadence/pull/86 used the wrong UDS protocol. This PR uses the correct protocol along with some cleanup.

Fixes https://github.com/tshlabs/cadence/issues/88