### PR TITLE
Add an option to create a QueuingMetricSink with a bounded queue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,13 @@ rust:
   - stable
   - beta
   - nightly
-  - 1.32.0
-  - 1.33.0
   - 1.34.0
   - 1.35.0
   - 1.36.0
   - 1.37.0
   - 1.38.0
   - 1.39.0
+  - 1.40.0
 
 matrix:
   allow_failures:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["statsd", "metrics"]
 edition = "2018"
 
 [dependencies]
-crossbeam-channel = "0.3.8"
+crossbeam-channel = "0.4.0"
 
 [lib]
 name = "cadence"

--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ additional terms or conditions.
 
 ## Language Support
 
-Cadence (latest master) supports building with a range of `1.32+` versions.
+Cadence (latest master) supports building with a range of `1.34+` versions.
 
 ### Guaranteed to Build
 

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -12,21 +12,21 @@ use cadence::{
     StatsdClient, Timer, UdpMetricSink, DEFAULT_PORT,
 };
 
+const TARGET_HOST: (&str, u16) = ("127.0.0.1", DEFAULT_PORT);
+
 fn new_nop_client() -> StatsdClient {
     StatsdClient::from_sink("client.bench", NopMetricSink)
 }
 
 fn new_udp_client() -> StatsdClient {
-    let host = ("127.0.0.1", DEFAULT_PORT);
     let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
-    let sink = UdpMetricSink::from(host, socket).unwrap();
+    let sink = UdpMetricSink::from(TARGET_HOST, socket).unwrap();
     StatsdClient::from_sink("client.bench", sink)
 }
 
 fn new_buffered_udp_client() -> StatsdClient {
-    let host = ("127.0.0.1", DEFAULT_PORT);
     let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
-    let sink = BufferedUdpMetricSink::from(host, socket).unwrap();
+    let sink = BufferedUdpMetricSink::from(TARGET_HOST, socket).unwrap();
     StatsdClient::from_sink("client.bench", sink)
 }
 

--- a/src/sinks/queuing.rs
+++ b/src/sinks/queuing.rs
@@ -8,17 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use crate::sinks::core::MetricSink;
+use crossbeam_channel::{self, Receiver, Sender, TrySendError};
 use std::fmt;
-use std::io;
+use std::io::{self, ErrorKind};
 use std::panic::RefUnwindSafe;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::thread;
-
-use crossbeam_channel::{self, Receiver, Sender};
-
-use crate::sinks::core::MetricSink;
 
 /// Implementation of a `MetricSink` that wraps another implementation
 /// and uses it to emit metrics asynchronously, in another thread.
@@ -33,6 +30,17 @@ use crate::sinks::core::MetricSink;
 /// is created. The dequeuing of metrics is stopped and the thread stopped
 /// when `QueuingMetricSink` instance is destroyed (when `.drop()` is
 /// called).
+///
+/// This sink may be created with either a bounded or unbounded queue
+/// connecting the sink to the thread performning network operations. When an
+/// unbounded queue is used, entries submitted to the sink will always be
+/// accepted and queued until they can be drained by the network operation
+/// thread. This means that if the network thread cannot drain entries off
+/// the queue for some reason, it will grow without bound. Alternatively, if
+/// created with a bounded queue, entries submitted to the sink will not be
+/// accepted if the queue is full. This means that the network thread must
+/// be able to keep up with the rate of entries submit to the queue or writes
+/// to this sink will begin to fail.
 ///
 /// Entries already queued are guaranteed to be sent to the wrapped sink
 /// before the queuing sink is stopped. Meaning, the following code ends up
@@ -58,12 +66,12 @@ use crate::sinks::core::MetricSink;
 /// sink is stopped.
 #[derive(Debug, Clone)]
 pub struct QueuingMetricSink {
-    context: Arc<WorkerContext<String>>,
+    worker: Arc<Worker<String>>,
 }
 
 impl QueuingMetricSink {
     /// Construct a new `QueuingMetricSink` instance wrapping another sink
-    /// implementation.
+    /// implementation with an unbounded queue connecting them.
     ///
     /// The `.emit()` method of the wrapped sink will be executed in a
     /// different thread after being passed to it via a queue. The wrapped
@@ -73,6 +81,10 @@ impl QueuingMetricSink {
     /// The thread in which the wrapped sink runs is created when the
     /// `QueuingMetricSink` is created and stopped when the queuing sink
     /// is destroyed.
+    ///
+    /// The queuing sink communicates with the wrapped sink by an unbounded
+    /// queue. If entries cannot be drained from the queue for some reason, it
+    /// will grow without bound.
     ///
     /// # Buffered UDP Sink Example
     ///
@@ -88,31 +100,97 @@ impl QueuingMetricSink {
     /// let udp_sink = BufferedUdpMetricSink::from(host, socket).unwrap();
     /// let queuing_sink = QueuingMetricSink::from(udp_sink);
     /// ```
-    pub fn from<T>(sink: T) -> QueuingMetricSink
+    pub fn from<T>(sink: T) -> Self
     where
         T: MetricSink + Sync + Send + RefUnwindSafe + 'static,
     {
-        let worker = Worker::new(move |v: String| {
-            let _r = sink.emit(&v);
-        });
-        let context = Arc::new(WorkerContext::new(worker));
-        spawn_worker_in_thread(Arc::clone(&context));
+        Self::with_optional_capacity(sink, None)
+    }
 
-        QueuingMetricSink { context }
+    /// Construct a new `QueuingMetricSink` instance wrapping another sink
+    /// implementation with a queue of the given size connecting them.
+    ///
+    /// The `.emit()` method of the wrapped sink will be executed in a
+    /// different thread after being passed to it via a queue. The wrapped
+    /// sink should be thread safe (`Send + Sync`) and panic safe
+    /// (`RefUnwindSafe`).
+    ///
+    /// The thread in which the wrapped sink runs is created when the
+    /// `QueuingMetricSink` is created and stopped when the queuing sink
+    /// is destroyed.
+    ///
+    /// The queuing sink communicates with the wrapped sink by a bounded
+    /// queue of the provided size. When the queue is full, writes to
+    /// this sink will fail until the queue is drained.
+    ///
+    /// # Buffered UDP Sink Example
+    ///
+    /// In this example we wrap a buffered UDP sink to execute it in a
+    /// different thread.
+    ///
+    /// ```no_run
+    /// use std::net::UdpSocket;
+    /// use cadence::{BufferedUdpMetricSink, QueuingMetricSink, DEFAULT_PORT};
+    ///
+    /// let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+    /// let host = ("metrics.example.com", DEFAULT_PORT);
+    /// let udp_sink = BufferedUdpMetricSink::from(host, socket).unwrap();
+    /// let queuing_sink = QueuingMetricSink::with_capacity(udp_sink, 512 * 1024);
+    /// ```
+    pub fn with_capacity<T>(sink: T, capacity: usize) -> Self
+    where
+        T: MetricSink + Sync + Send + RefUnwindSafe + 'static,
+    {
+        Self::with_optional_capacity(sink, Some(capacity))
+    }
+
+    fn with_optional_capacity<T>(sink: T, capacity: Option<usize>) -> Self
+    where
+        T: MetricSink + Sync + Send + RefUnwindSafe + 'static,
+    {
+        let worker = Arc::new(Worker::new(capacity, move |v: String| {
+            let _r = sink.emit(&v);
+        }));
+        spawn_worker_in_thread(Arc::clone(&worker));
+
+        QueuingMetricSink { worker }
     }
 
     /// Return the number of times the wrapped sink or underlying worker thread
     /// has panicked and needed to be restarted. In typical use this should always
-    /// be `0` but sometimes bugs happen.
-    pub fn panics(&self) -> usize {
-        self.context.stats.panics()
+    /// be `0` but may be `> 0` for buggy `MetricSink` implementations.
+    pub fn panics(&self) -> u64 {
+        self.worker.stats.panics()
+    }
+
+    /// Return the number of currently queued metrics. Note that due to the way
+    /// this number is computed (submitted metrics - processed metrics), it is
+    /// necessarily approximate.
+    pub fn queued(&self) -> u64 {
+        self.worker.stats.queued()
+    }
+
+    /// Return the number of metrics successfully submitted to this sink.
+    pub fn submitted(&self) -> u64 {
+        self.worker.stats.submitted()
+    }
+
+    /// Return the number of metrics removed from the queue to be processed by
+    /// the wrapped sink. Note that this does not indicate that the metric has
+    /// been successfully sent to a backend, only that it has been passed to
+    /// the wrapped sink.
+    pub fn drained(&self) -> u64 {
+        self.worker.stats.drained()
     }
 }
 
 impl MetricSink for QueuingMetricSink {
     fn emit(&self, metric: &str) -> io::Result<usize> {
-        self.context.worker.submit(metric.to_string());
-        Ok(metric.len())
+        match self.worker.submit(metric.to_string()) {
+            Err(TrySendError::Disconnected(_)) => Err(io::Error::new(ErrorKind::Other, "channel disconnected")),
+            Err(TrySendError::Full(_)) => Err(io::Error::new(ErrorKind::Other, "channel full")),
+            Ok(_) => Ok(metric.len()),
+        }
     }
 }
 
@@ -122,7 +200,7 @@ impl Drop for QueuingMetricSink {
     /// Note that this destructor only sends the worker thread a signal to
     /// stop, it doesn't wait for it to stop.
     fn drop(&mut self) {
-        self.context.worker.stop();
+        self.worker.stop();
     }
 }
 
@@ -133,13 +211,17 @@ impl Drop for QueuingMetricSink {
 /// is running in.
 #[derive(Debug)]
 struct WorkerStats {
-    panics: AtomicUsize,
+    panics: AtomicU64,
+    submitted: AtomicU64,
+    drained: AtomicU64,
 }
 
 impl WorkerStats {
     fn new() -> WorkerStats {
         WorkerStats {
-            panics: AtomicUsize::new(0),
+            panics: AtomicU64::new(0),
+            submitted: AtomicU64::new(0),
+            drained: AtomicU64::new(0),
         }
     }
 
@@ -147,32 +229,34 @@ impl WorkerStats {
         self.panics.fetch_add(1, Ordering::Release);
     }
 
-    fn panics(&self) -> usize {
+    fn panics(&self) -> u64 {
         self.panics.load(Ordering::Acquire)
     }
-}
 
-/// Holder for a worker and statistics about it.
-///
-/// Users of the context are expected to directly reference the members
-/// of this struct.
-#[derive(Debug)]
-struct WorkerContext<T>
-where
-    T: Send + 'static,
-{
-    worker: Worker<T>,
-    stats: WorkerStats,
-}
+    fn incr_submitted(&self) {
+        self.submitted.fetch_add(1, Ordering::Release);
+    }
 
-impl<T> WorkerContext<T>
-where
-    T: Send + 'static,
-{
-    fn new(worker: Worker<T>) -> WorkerContext<T> {
-        WorkerContext {
-            worker,
-            stats: WorkerStats::new(),
+    fn submitted(&self) -> u64 {
+        self.submitted.load(Ordering::Acquire)
+    }
+
+    fn incr_drained(&self) {
+        self.drained.fetch_add(1, Ordering::Release);
+    }
+
+    fn drained(&self) -> u64 {
+        self.drained.load(Ordering::Acquire)
+    }
+
+    fn queued(&self) -> u64 {
+        let submitted = self.submitted.load(Ordering::Acquire);
+        let drained = self.drained.load(Ordering::Acquire);
+
+        if submitted > drained {
+            submitted - drained
+        } else {
+            0
         }
     }
 }
@@ -182,13 +266,13 @@ where
 /// This function uses a `Sentinel` struct to make sure that any panics from
 /// running the worker result in another thread being spawned to start running
 /// the worker again.
-fn spawn_worker_in_thread<T>(context: Arc<WorkerContext<T>>) -> thread::JoinHandle<()>
+fn spawn_worker_in_thread<T>(worker: Arc<Worker<T>>) -> thread::JoinHandle<()>
 where
     T: Send + 'static,
 {
     thread::spawn(move || {
-        let mut sentinel = Sentinel::new(&context);
-        context.worker.run();
+        let mut sentinel = Sentinel::new(&worker);
+        worker.run();
         sentinel.cancel();
     })
 }
@@ -204,7 +288,7 @@ struct Sentinel<'a, T>
 where
     T: Send + 'static,
 {
-    context: &'a Arc<WorkerContext<T>>,
+    worker: &'a Arc<Worker<T>>,
     active: bool,
 }
 
@@ -212,11 +296,8 @@ impl<'a, T> Sentinel<'a, T>
 where
     T: Send + 'static,
 {
-    fn new(context: &'a Arc<WorkerContext<T>>) -> Sentinel<'a, T> {
-        Sentinel {
-            context,
-            active: true,
-        }
+    fn new(worker: &'a Arc<Worker<T>>) -> Sentinel<'a, T> {
+        Sentinel { worker, active: true }
     }
 
     fn cancel(&mut self) {
@@ -233,9 +314,9 @@ where
             // This sentinel didn't have its `.cancel()`method called so
             // the thread must have panicked. Increment a counter indicating
             // that this was a panic and spawn a new thread with an Arc of
-            // the worker and its context.
-            self.context.stats.incr_panic();
-            spawn_worker_in_thread(Arc::clone(self.context));
+            // the worker.
+            self.worker.stats.incr_panic();
+            spawn_worker_in_thread(Arc::clone(self.worker));
         }
     }
 }
@@ -269,37 +350,48 @@ where
     sender: Sender<Option<T>>,
     receiver: Receiver<Option<T>>,
     stopped: AtomicBool,
+    stats: WorkerStats,
 }
 
 impl<T> Worker<T>
 where
     T: Send + 'static,
 {
-    fn new<F>(task: F) -> Worker<T>
+    fn new<F>(capacity: Option<usize>, task: F) -> Worker<T>
     where
         F: Fn(T) -> () + Sync + Send + RefUnwindSafe + 'static,
     {
-        let (tx, rx) = crossbeam_channel::unbounded();
-
+        let (tx, rx) = Self::get_channels(capacity);
         Worker {
             task: Box::new(task),
             sender: tx,
             receiver: rx,
             stopped: AtomicBool::new(false),
+            stats: WorkerStats::new(),
         }
     }
 
-    fn submit(&self, v: T) {
-        // Errors are ignored since the channel cannot be full and
-        // disconnection means senders and receivers have been dropped
-        // (which means we're shutting down and nothing could be sending
-        // anything else via this channel anyway).
-        let _ = self.sender.try_send(Some(v));
+    fn get_channels(capacity: Option<usize>) -> (Sender<Option<T>>, Receiver<Option<T>>) {
+        if let Some(v) = capacity {
+            crossbeam_channel::bounded(v)
+        } else {
+            crossbeam_channel::unbounded()
+        }
+    }
+
+    fn submit(&self, v: T) -> Result<(), TrySendError<Option<T>>> {
+        let res = self.sender.try_send(Some(v));
+        if res.is_ok() {
+            self.stats.incr_submitted();
+        }
+
+        res
     }
 
     fn run(&self) {
         for opt in self.receiver.iter() {
             if let Some(v) = opt {
+                self.stats.incr_drained();
                 (self.task)(v);
             } else {
                 break;
@@ -361,6 +453,8 @@ mod tests {
     use std::sync::{Arc, Mutex};
     use std::thread;
 
+    const QUEUE_SIZE: Option<usize> = Some(128);
+
     #[test]
     fn test_worker_submit_processes_event() {
         let flag = Arc::new(AtomicBool::new(false));
@@ -372,15 +466,15 @@ mod tests {
             }
         };
 
-        let worker = Arc::new(Worker::new(task));
+        let worker = Arc::new(Worker::new(QUEUE_SIZE, task));
         let worker_ref = worker.clone();
 
         let t = thread::spawn(move || {
             worker_ref.run();
         });
 
-        worker.submit("bar".to_string());
-        worker.submit("foo".to_string());
+        worker.submit("bar".to_string()).unwrap();
+        worker.submit("foo".to_string()).unwrap();
         worker.stop();
         t.join().unwrap();
 
@@ -389,7 +483,7 @@ mod tests {
 
     #[test]
     fn test_worker_stop() {
-        let worker = Arc::new(Worker::new(move |_: String| {}));
+        let worker = Arc::new(Worker::new(QUEUE_SIZE, move |_: String| {}));
         let worker_ref = worker.clone();
 
         let t = thread::spawn(move || {
@@ -404,7 +498,7 @@ mod tests {
 
     #[test]
     fn test_worker_stop_and_wait() {
-        let worker = Arc::new(Worker::new(move |_: String| {}));
+        let worker = Arc::new(Worker::new(QUEUE_SIZE, move |_: String| {}));
         let worker_ref = worker.clone();
 
         let _t = thread::spawn(move || {
@@ -419,13 +513,13 @@ mod tests {
     // when the producer size of the channel panics.
     #[test]
     fn test_worker_panic_on_submit_side() {
-        let worker = Arc::new(Worker::new(move |_: String| {}));
+        let worker = Arc::new(Worker::new(QUEUE_SIZE, move |_: String| {}));
         let worker_ref1 = worker.clone();
         let worker_ref2 = worker.clone();
 
         #[allow(unreachable_code)]
         let t1 = thread::spawn(move || {
-            worker_ref1.submit(panic!("This thread is supposed to panic"));
+            worker_ref1.submit(panic!("This thread is supposed to panic")).unwrap();
         });
 
         let t2 = thread::spawn(move || {
@@ -445,14 +539,14 @@ mod tests {
     // when the consumer side of the channel panics.
     #[test]
     fn test_worker_panic_on_run_side() {
-        let worker = Arc::new(Worker::new(move |_: String| {
+        let worker = Arc::new(Worker::new(QUEUE_SIZE, move |_: String| {
             panic!("This thread is supposed to panic");
         }));
         let worker_ref1 = worker.clone();
         let worker_ref2 = worker.clone();
 
         let t1 = thread::spawn(move || {
-            worker_ref1.submit("foo".to_owned());
+            worker_ref1.submit("foo".to_owned()).unwrap();
         });
 
         let t2 = thread::spawn(move || {
@@ -493,7 +587,7 @@ mod tests {
         queuing.emit("foo.counter:1|c").unwrap();
         queuing.emit("bar.counter:2|c").unwrap();
         queuing.emit("baz.counter:3|c").unwrap();
-        queuing.context.worker.stop_and_wait();
+        queuing.worker.stop_and_wait();
 
         assert_eq!("foo.counter:1|c".to_string(), store.lock().unwrap()[0]);
         assert_eq!("bar.counter:2|c".to_string(), store.lock().unwrap()[1]);
@@ -514,7 +608,7 @@ mod tests {
         queuing.emit("foo.counter:4|c").unwrap();
         queuing.emit("foo.counter:5|c").unwrap();
         queuing.emit("foo.timer:34|ms").unwrap();
-        queuing.context.worker.stop_and_wait();
+        queuing.worker.stop_and_wait();
 
         assert_eq!(3, queuing.panics());
     }
@@ -557,7 +651,7 @@ mod tests {
         queuing.emit("foo.counter:4|c").unwrap();
         queuing.emit("foo.counter:5|c").unwrap();
         queuing.emit("foo.timer:34|ms").unwrap();
-        queuing.context.worker.stop_and_wait();
+        queuing.worker.stop_and_wait();
 
         assert_eq!(1, queuing.panics());
         assert_eq!("foo.counter:5|c".to_string(), store.lock().unwrap()[0]);
@@ -582,9 +676,44 @@ mod tests {
             queuing.emit("foo.counter:4|c").unwrap();
             queuing.emit("foo.counter:5|c").unwrap();
             queuing.emit("foo.timer:34|ms").unwrap();
-            queuing.context.worker.stop_and_wait();
+            queuing.worker.stop_and_wait();
         });
 
         assert!(res.is_ok());
+    }
+
+    // Make sure that attempts to write to the sink start to fail when none of the
+    // metrics have been drained by the wrapped sink. This is simulated by wrapping a
+    // sink that sleeps indefinitely. Since all threads in Rust are daemon threads we
+    // don't care that this thread won't stop, it'll be killed when the test process
+    // exits.
+    #[test]
+    fn test_queuing_metric_sink_blocking_sink_back_pressure() {
+        struct BlockingMetricSink;
+
+        impl MetricSink for BlockingMetricSink {
+            fn emit(&self, _m: &str) -> io::Result<usize> {
+                loop {
+                    thread::park();
+                }
+            }
+        }
+
+        let queueing = QueuingMetricSink::with_capacity(BlockingMetricSink, 1);
+        let results = vec![
+            queueing.emit("foo.counter:1|c"),
+            queueing.emit("foo.counter:2|c"),
+            queueing.emit("foo.counter:3|c"),
+        ];
+
+        let success = results.iter().map(|r| r.is_ok()).filter(|r| *r).count();
+        let failure = results.iter().map(|r| r.is_err()).filter(|r| *r).count();
+
+        // We've submitted three metrics to a queuing sink with a max capacity of one: at least
+        // one of the submissions should be successfully queued and one of them should have failed.
+        // Depending on how quickly the network thread of the sink started running, an entry may
+        // have been removed from the queue (meaning that two submissions would have succeeded).
+        assert!(success >= 1, "At least one submission to the queue should have succeeded");
+        assert!(failure >= 1, "At least one submission to the queue should have failed");
     }
 }


### PR DESCRIPTION
Add a constructor to create a QueuingMetricSink with a bounded queue
size to enable back pressure when the wrapped sink cannot keep up with
the rate of metrics submitted to it. The unbounded constructor is still
available for users that want the old behavior.

When the max queue size is reached, writes to the queuing sink will fail
until the wrapped sink begins to drain entries. There is no "default" size
for the bounded queue and so users must make this determination on their
own for now. Based on the expected rate of metrics being sent, a queue
size of 64K entries or more may make sense. This is left as an exercise
for the savvy user.

Fixes #95