### PR TITLE
Histogram methods to support recording Durations as nanoseconds

### DIFF
--- a/examples/tag-view.rs
+++ b/examples/tag-view.rs
@@ -154,6 +154,19 @@ impl Histogrammed for MetricTagDecorator {
 
         builder
     }
+
+    fn histogram_duration_with_tags<'a>(
+        &'a self,
+        key: &'a str,
+        duration: Duration,
+    ) -> MetricBuilder<'_, '_, Histogram> {
+        let mut builder = self.client.histogram_duration_with_tags(key, duration);
+        for (tkey, tval) in self.tags.iter() {
+            builder = builder.with_tag(tkey, tval);
+        }
+
+        builder
+    }
 }
 
 impl Setted for MetricTagDecorator {

--- a/src/client.rs
+++ b/src/client.rs
@@ -195,10 +195,10 @@ pub trait Histogrammed {
 
     /// Record a single histogram value with the given key.
     ///
-    /// The duration will be converted to nanoseconds. If the duration cannot
-    /// be represented as a `u64` an error will be returned. Although
-    /// histograms don't necessarily represent times, this method is provided
-    /// as a convenience.
+    /// The duration will be converted to nanoseconds. If the duration
+    /// cannot be represented as a `u64` an error will be returned. Note
+    /// that histograms are an extension to Statsd, you'll need to check
+    /// if they are supported by your server and considered times.
     fn histogram_duration(&self, key: &str, duration: Duration) -> MetricResult<Histogram> {
         self.histogram_duration_with_tags(key, duration).try_send()
     }
@@ -208,8 +208,9 @@ pub trait Histogrammed {
     ///
     /// The duration will be converted to nanoseconds. If the duration cannot
     /// be represented as a `u64` an error will be deferred and returned when
-    /// `MetricBuilder::try_send()` is called. Although histograms don't
-    /// necessarily represent times, this method is provided as a convenience.
+    /// `MetricBuilder::try_send()` is called. Note that histograms are an
+    /// extension to Statsd, you'll need to check if they are supported by
+    /// your server and considered times.
     fn histogram_duration_with_tags<'a>(
         &'a self,
         key: &'a str,


### PR DESCRIPTION
Add methods to the Histogram trait to support writing stdlib Durations
as nanoseconds. Histogram values aren't technically times but this makes
it more convenience to record sub-millisecond times.

Note that a u64 (what histograms use) can only represent Durations of
roughly 500 years as nanoseconds. This shouldn't be an issue in practice
but if a Duration is passed to the methods in question, an error will be
returned.

/cc @parasyte

Fixes #98